### PR TITLE
Gauss-Jordan elimination for scalar matrices

### DIFF
--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/Matrix4x4.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/Matrix4x4.h
@@ -671,14 +671,16 @@ namespace EmuMath
 		///		Note that this operation does not check that the determinant is not 0. As matrices with a determinant of 0 have no inverse, it is recommended to 
 		///		use the outDeterminant argument to test if the output matrix is valid if there should there be a chance that the passed matrix's determinant will be 0.
 		/// </para>
-		/// <para> NOTE: Laplace Expansion grows exponentially more expensive as the size of a matrix increases. </para>
+		/// <para>
+		///		NOTE: Laplace Expansion grows exponentially more expensive as the size of a matrix increases. 
+		///		Its time complexity may be considered O(n!), where n is the size of this matrix in any one dimension.
+		/// </para>
 		/// </summary>
 		/// <typeparam name="out_contained_type">Type to be contained in the output inverse matrix.</typeparam>
-		/// <typeparam name="OutDeterminant_">Type to optionally output the matrix's determinant as.</typeparam>
-		/// <param name="matrix_">EmuMath matrix to find the inverse of.</param>
-		/// <param name="outDeterminant_">
-		///		Optional reference to output the passed matrix's determinant to. 
-		///		Useful to test if the determinant is 0 in cases where a non-invertible matrix may potentially be passed.
+		/// <typeparam name="OutDeterminant_">Type to optionally output this matrix's determinant as.</typeparam>
+		/// <param name="out_determinant_">
+		///		Optional reference to output this matrix's determinant to. 
+		///		Useful to test if the determinant is 0 in cases where this matrix is not invertible.
 		/// </param>
 		/// <returns>Inverted version of this matrix if it is invertible. Otherwise, a matrix containing the results of multiplying its adjugate by (1/0).</returns>
 		template<typename out_contained_type = preferred_floating_point, bool OutColumnMajor_ = is_column_major>
@@ -693,6 +695,37 @@ namespace EmuMath
 		) const
 		{
 			return EmuMath::Helpers::MatrixInverseLaplace<out_contained_type, OutColumnMajor_, this_type, OutDeterminant_>(*this, out_determinant_);
+		}
+
+		/// <summary>
+		/// <para> Calculates the inverse to this matrix using Gauss-Jordan elimination. May optionally output the determinant as a customisable type. </para>
+		/// <para> Note that this operation does not check that the determinant is not 0. </para>
+		/// <para> NOTE: Gauss-Jordan's time complexity may be considered O(n*n*n), where n is the size of this matrix in any one dimension. </para>
+		/// <para> Especially recommended over laplace expansion when working with large matrices. </para>
+		/// </summary>
+		/// <typeparam name="out_contained_type">Type to be contained in the output inverse matrix.</typeparam>
+		/// <typeparam name="OutDeterminant_">Type to optionally output this matrix's determinant as.</typeparam>
+		/// <param name="out_determinant_">Optional reference to output this matrix's determinant to.</param>
+		/// <returns>Inverted version of this matrix if it is invertible. Otherwise, a matrix resulting from simultaneous Gauss-Jordan elimination with its values.</returns>
+		template<typename out_contained_type, bool OutColumnMajor_ = is_column_major>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, out_contained_type, OutColumnMajor_> InverseGaussJordan() const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<out_contained_type, OutColumnMajor_, this_type>(*this);
+		}
+		template<bool OutColumnMajor_ = is_column_major>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, preferred_floating_point, OutColumnMajor_> InverseGaussJordan() const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<preferred_floating_point, OutColumnMajor_, this_type>(*this);
+		}
+		template<typename out_contained_type, bool OutColumnMajor_ = is_column_major, typename OutDeterminant_>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, out_contained_type, OutColumnMajor_> InverseGaussJordan(OutDeterminant_& out_determinant_) const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<out_contained_type, OutColumnMajor_, this_type>(*this, out_determinant_);
+		}
+		template<bool OutColumnMajor_ = is_column_major, typename OutDeterminant_>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, preferred_floating_point, OutColumnMajor_> InverseGaussJordan(OutDeterminant_& out_determinant_) const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<preferred_floating_point, OutColumnMajor_, this_type>(*this, out_determinant_);
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/MatrixT.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/MatrixT.h
@@ -623,14 +623,16 @@ namespace EmuMath
 		///		Note that this operation does not check that the determinant is not 0. As matrices with a determinant of 0 have no inverse, it is recommended to 
 		///		use the outDeterminant argument to test if the output matrix is valid if there should there be a chance that the passed matrix's determinant will be 0.
 		/// </para>
-		/// <para> NOTE: Laplace Expansion grows exponentially more expensive as the size of a matrix increases. </para>
+		/// <para>
+		///		NOTE: Laplace Expansion grows exponentially more expensive as the size of a matrix increases. 
+		///		Its time complexity may be considered O(n!), where n is the size of this matrix in any one dimension.
+		/// </para>
 		/// </summary>
 		/// <typeparam name="out_contained_type">Type to be contained in the output inverse matrix.</typeparam>
-		/// <typeparam name="OutDeterminant_">Type to optionally output the matrix's determinant as.</typeparam>
-		/// <param name="matrix_">EmuMath matrix to find the inverse of.</param>
-		/// <param name="outDeterminant_">
-		///		Optional reference to output the passed matrix's determinant to. 
-		///		Useful to test if the determinant is 0 in cases where a non-invertible matrix may potentially be passed.
+		/// <typeparam name="OutDeterminant_">Type to optionally output this matrix's determinant as.</typeparam>
+		/// <param name="out_determinant_">
+		///		Optional reference to output this matrix's determinant to. 
+		///		Useful to test if the determinant is 0 in cases where this matrix is not invertible.
 		/// </param>
 		/// <returns>Inverted version of this matrix if it is invertible. Otherwise, a matrix containing the results of multiplying its adjugate by (1/0).</returns>
 		template<typename out_contained_type = preferred_floating_point, bool OutColumnMajor_ = is_column_major>
@@ -645,6 +647,37 @@ namespace EmuMath
 		) const
 		{
 			return EmuMath::Helpers::MatrixInverseLaplace<out_contained_type, OutColumnMajor_, this_type, OutDeterminant_>(*this, out_determinant_);
+		}
+
+		/// <summary>
+		/// <para> Calculates the inverse to this matrix using Gauss-Jordan elimination. May optionally output the determinant as a customisable type. </para>
+		/// <para> Note that this operation does not check that the determinant is not 0. </para>
+		/// <para> NOTE: Gauss-Jordan's time complexity may be considered O(n*n*n), where n is the size of this matrix in any one dimension. </para>
+		/// <para> Especially recommended over laplace expansion when working with large matrices. </para>
+		/// </summary>
+		/// <typeparam name="out_contained_type">Type to be contained in the output inverse matrix.</typeparam>
+		/// <typeparam name="OutDeterminant_">Type to optionally output this matrix's determinant as.</typeparam>
+		/// <param name="out_determinant_">Optional reference to output this matrix's determinant to.</param>
+		/// <returns>Inverted version of this matrix if it is invertible. Otherwise, a matrix resulting from simultaneous Gauss-Jordan elimination with its values.</returns>
+		template<typename out_contained_type, bool OutColumnMajor_ = is_column_major>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, out_contained_type, OutColumnMajor_> InverseGaussJordan() const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<out_contained_type, OutColumnMajor_, this_type>(*this);
+		}
+		template<bool OutColumnMajor_ = is_column_major>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, preferred_floating_point, OutColumnMajor_> InverseGaussJordan() const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<preferred_floating_point, OutColumnMajor_, this_type>(*this);
+		}
+		template<typename out_contained_type, bool OutColumnMajor_ = is_column_major, typename OutDeterminant_>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, out_contained_type, OutColumnMajor_> InverseGaussJordan(OutDeterminant_& out_determinant_) const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<out_contained_type, OutColumnMajor_, this_type>(*this, out_determinant_);
+		}
+		template<bool OutColumnMajor_ = is_column_major, typename OutDeterminant_>
+		constexpr inline EmuMath::Matrix<num_columns, num_rows, preferred_floating_point, OutColumnMajor_> InverseGaussJordan(OutDeterminant_& out_determinant_) const
+		{
+			return EmuMath::Helpers::MatrixInverseGaussJordan<preferred_floating_point, OutColumnMajor_, this_type>(*this, out_determinant_);
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/_helpers/_matrix_operations.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrices/_helpers/_matrix_operations.h
@@ -699,13 +699,14 @@ namespace EmuMath::Helpers
 		}
 	}
 	template<bool OutColumnMajor_, class Matrix_, typename OutDeterminant_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::value_type, OutColumnMajor_, Matrix_>::type MatrixInverseLaplace
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_>::type
+	MatrixInverseLaplace
 	(
 		const Matrix_& matrix_,
 		OutDeterminant_& outDeterminant_
 	)
 	{
-		return MatrixInverseLaplace<typename Matrix_::value_type, OutColumnMajor_, Matrix_, OutDeterminant_>(matrix_, outDeterminant_);
+		return MatrixInverseLaplace<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_, OutDeterminant_>(matrix_, outDeterminant_);
 	}
 	template<typename out_contained_type, class Matrix_, typename OutDeterminant_>
 	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<out_contained_type, Matrix_::is_column_major, Matrix_>::type MatrixInverseLaplace
@@ -717,13 +718,14 @@ namespace EmuMath::Helpers
 		return MatrixInverseLaplace<out_contained_type, Matrix_::is_column_major, Matrix_, OutDeterminant_>(matrix_, outDeterminant_);
 	}
 	template<class Matrix_, typename OutDeterminant_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::value_type, Matrix_::is_column_major, Matrix_>::type MatrixInverseLaplace
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_>::type
+	MatrixInverseLaplace
 	(
 		const Matrix_& matrix_,
 		OutDeterminant_& outDeterminant_
 	)
 	{
-		return MatrixInverseLaplace<typename Matrix_::value_type, Matrix_::is_column_major, Matrix_, OutDeterminant_>(matrix_, outDeterminant_);
+		return MatrixInverseLaplace<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_, OutDeterminant_>(matrix_, outDeterminant_);
 	}
 	template<typename out_contained_type, bool OutColumnMajor_, class Matrix_>
 	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<out_contained_type, OutColumnMajor_, Matrix_>::type MatrixInverseLaplace
@@ -736,12 +738,13 @@ namespace EmuMath::Helpers
 		return MatrixInverseLaplace<out_contained_type, OutColumnMajor_, Matrix_, dummy_output_type>(matrix_, reciprocal_dummy_output_);
 	}
 	template<bool OutColumnMajor_, class Matrix_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::value_type, OutColumnMajor_, Matrix_>::type MatrixInverseLaplace
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_>::type
+	MatrixInverseLaplace
 	(
 		const Matrix_& matrix_
 	)
 	{
-		return MatrixInverseLaplace<typename Matrix_::value_type, OutColumnMajor_, Matrix_>(matrix_);
+		return MatrixInverseLaplace<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_>(matrix_);
 	}
 	template<typename out_contained_type, class Matrix_>
 	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<out_contained_type, Matrix_::is_column_major, Matrix_>::type MatrixInverseLaplace
@@ -752,12 +755,149 @@ namespace EmuMath::Helpers
 		return MatrixInverseLaplace<out_contained_type, Matrix_::is_column_major, Matrix_>(matrix_);
 	}
 	template<class Matrix_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::value_type, Matrix_::is_column_major, Matrix_>::type MatrixInverseLaplace
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::emu_matrix_transpose<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_>::type
+	MatrixInverseLaplace
 	(
 		const Matrix_& matrix_
 	)
 	{
-		return MatrixInverseLaplace<typename Matrix_::value_type, Matrix_::is_column_major, Matrix_>(matrix_);
+		return MatrixInverseLaplace<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Calculates the inverse to the passed matrix using Gauss-Jordan elimination. May optionally output the determinant as a customisable type. </para>
+	/// <para> Note that this operation does not check that the determinant is not 0. </para>
+	/// <para> NOTE: Gauss-Jordan's time complexity may be considered O(n*n*n), where n is the size of the passed matrix in any one dimension. </para>
+	/// <para> Especially recommended over laplace expansion when working with large matrices. </para>
+	/// </summary>
+	/// <typeparam name="out_contained_type">Type to be contained in the output inverse matrix.</typeparam>
+	/// <typeparam name="OutDeterminant_">Type to optionally output the matrix's determinant as.</typeparam>
+	/// <param name="matrix_">EmuMath matrix to find the inverse of.</param>
+	/// <param name="out_determinant_">Optional reference to output the passed matrix's determinant to.</param>
+	/// <returns>Inverted version of the passed matrix if it is invertible. Otherwise, a matrix resulting from simultaneous Gauss-Jordan elimination with its values.</returns>
+	template<typename out_contained_type, bool OutColumnMajor_, class Matrix_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_> MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_
+	)
+	{
+		if constexpr (EmuMath::TMP::is_emu_matrix_v<Matrix_>)
+		{
+			if constexpr (Matrix_::is_square)
+			{
+				return _underlying_matrix_funcs::_calculate_matrix_inverse_gj
+				<
+					EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_>,
+					Matrix_,
+					typename EmuCore::TMPHelpers::first_floating_point
+					<
+						out_contained_type,
+						typename Matrix_::value_type,
+						typename EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_>::preferred_floating_point
+					>::type
+				>(matrix_);
+			}
+			else
+			{
+				static_assert(false, "Attempted to calculate an inverse matrix, but provided a non-square EmuMath matrix. Only square matrices are valid for this operation.");
+			}
+		}
+		else
+		{
+			static_assert(false, "Attempted to calculate an inverse matrix, but provided a non-EmuMath-matrix argument.");
+		}
+	}
+	template<bool OutColumnMajor_, class Matrix_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, typename Matrix_::preferred_floating_point, OutColumnMajor_>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_
+	)
+	{
+		return MatrixInverseGaussJordan<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_>(matrix_);
+	}
+	template<typename out_contained_type, class Matrix_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, Matrix_::is_column_major>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_
+	)
+	{
+		return MatrixInverseGaussJordan<out_contained_type, Matrix_::is_column_major, Matrix_>(matrix_);
+	}
+	template<class Matrix_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, typename Matrix_::preferred_floating_point, Matrix_::is_column_major>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_
+	)
+	{
+		return MatrixInverseGaussJordan<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_>(matrix_);
+	}
+	template<typename out_contained_type, bool OutColumnMajor_, class Matrix_, typename OutDeterminant_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_> MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_,
+		OutDeterminant_& out_determinant_
+	)
+	{
+		if constexpr (EmuMath::TMP::is_emu_matrix_v<Matrix_>)
+		{
+			if constexpr (Matrix_::is_square)
+			{
+				return _underlying_matrix_funcs::_calculate_matrix_inverse_gj
+				<
+					EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_>,
+					Matrix_,
+					typename EmuCore::TMPHelpers::first_floating_point
+					<
+						out_contained_type,
+						OutDeterminant_,
+						typename Matrix_::value_type,
+						typename EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, OutColumnMajor_>::preferred_floating_point
+					>::type,
+					OutDeterminant_
+				>(matrix_, out_determinant_);
+			}
+			else
+			{
+				static_assert(false, "Attempted to calculate an inverse matrix, but provided a non-square EmuMath matrix. Only square matrices are valid for this operation.");
+			}
+		}
+		else
+		{
+			static_assert(false, "Attempted to calculate an inverse matrix, but provided a non-EmuMath-matrix argument.");
+		}
+	}
+	template<bool OutColumnMajor_, class Matrix_, typename OutDeterminant_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, typename Matrix_::preferred_floating_point, OutColumnMajor_>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_,
+		OutDeterminant_& out_determinant_
+	)
+	{
+		return MatrixInverseGaussJordan<typename Matrix_::preferred_floating_point, OutColumnMajor_, Matrix_, OutDeterminant_>(matrix_, out_determinant_);
+	}
+	template<typename out_contained_type, class Matrix_, typename OutDeterminant_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, out_contained_type, Matrix_::is_column_major>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_,
+		OutDeterminant_& out_determinant_
+	)
+	{
+		return MatrixInverseGaussJordan<out_contained_type, Matrix_::is_column_major, Matrix_, OutDeterminant_>(matrix_, out_determinant_);
+	}
+	template<class Matrix_, typename OutDeterminant_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<Matrix_::num_columns, Matrix_::num_rows, typename Matrix_::preferred_floating_point, Matrix_::is_column_major>
+	MatrixInverseGaussJordan
+	(
+		const Matrix_& matrix_,
+		OutDeterminant_& out_determinant_
+	)
+	{
+		return MatrixInverseGaussJordan<typename Matrix_::preferred_floating_point, Matrix_::is_column_major, Matrix_, OutDeterminant_>(matrix_, out_determinant_);
 	}
 }
 

--- a/EmuMath/EmuMath/Tests.hpp
+++ b/EmuMath/EmuMath/Tests.hpp
@@ -26,7 +26,7 @@ namespace EmuCore::TestingHelpers
 		template<typename T_>
 		constexpr inline T_ operator()(const T_& dummy_) const
 		{
-			static constexpr typename EmuCore::TMPHelpers::first_floating_point<T_, float>::type MULT_ = 
+			typename EmuCore::TMPHelpers::first_floating_point<T_, float>::type MULT_ = 
 			static_cast<typename EmuCore::TMPHelpers::first_floating_point<T_, float>::type>(0.001f);
 
 			if constexpr (std::numeric_limits<T_>::max() < std::numeric_limits<int>::max())
@@ -397,10 +397,119 @@ namespace EmuCore::TestingHelpers
 		std::vector<DirectX::XMFLOAT4X4> out_readable_;
 	};
 
+	struct ScalarInverseLaplace
+	{
+		static constexpr bool PASS_LOOP_NUM = true;
+		static constexpr std::size_t NUM_LOOPS = 500000;
+		static constexpr bool WRITE_ALL_TIMES_TO_STREAM = false;
+		static constexpr bool DO_TEST = true;
+		static constexpr std::string_view NAME = "Inverse Laplace (Scalar)";
+		static constexpr std::size_t MatSize_ = 4;
+
+		ScalarInverseLaplace()
+		{
+		}
+		void Prepare()
+		{
+			in_.resize(NUM_LOOPS);
+			out_.resize(NUM_LOOPS);
+			VectorFiller filler_ = VectorFiller();
+			for (std::size_t i = 0; i < NUM_LOOPS; ++i)
+			{
+				in_[i] = in_[i].Mutate(filler_);
+				out_[i] = out_[i].Mutate(filler_);
+			}
+		}
+		void operator()(std::size_t i)
+		{
+			out_[i] = in_[i].InverseLaplace();
+		}
+		void OnTestsOver()
+		{
+			std::size_t i = static_cast<std::size_t>(rand()) % NUM_LOOPS;
+			std::cout << in_[i] << "\nINVERSE:\n" << out_[i] << "\n\n\n";
+		}
+
+		std::vector<EmuMath::Matrix<MatSize_, MatSize_, float, true>> in_;
+		std::vector<EmuMath::Matrix<MatSize_, MatSize_, float, true>> out_;
+	};
+	struct ScalarInverseGaussJordan
+	{
+		static constexpr bool PASS_LOOP_NUM = true;
+		static constexpr std::size_t NUM_LOOPS = 500000;
+		static constexpr bool WRITE_ALL_TIMES_TO_STREAM = false;
+		static constexpr bool DO_TEST = true;
+		static constexpr std::string_view NAME = "Inverse Gauss Jordan (Scalar)";
+		static constexpr std::size_t MatSize_ = 4;
+
+		ScalarInverseGaussJordan()
+		{
+		}
+		void Prepare()
+		{
+			in_.resize(NUM_LOOPS);
+			out_.resize(NUM_LOOPS);
+			VectorFiller filler_ = VectorFiller();
+			for (std::size_t i = 0; i < NUM_LOOPS; ++i)
+			{
+				in_[i] = in_[i].Mutate(filler_);
+				out_[i] = out_[i].Mutate(filler_);
+			}
+		}
+		void operator()(std::size_t i)
+		{
+			out_[i] = in_[i].InverseGaussJordan();
+		}
+		void OnTestsOver()
+		{
+			std::size_t i = static_cast<std::size_t>(rand()) % NUM_LOOPS;
+			std::cout << in_[i] << "\nINVERSE:\n" << out_[i] << "\n\n\n";
+		}
+
+		std::vector<EmuMath::Matrix<MatSize_, MatSize_, float, true>> in_;
+		std::vector<EmuMath::Matrix<MatSize_, MatSize_, float, true>> out_;
+	};
+	struct FastInverse
+	{
+		static constexpr bool PASS_LOOP_NUM = true;
+		static constexpr std::size_t NUM_LOOPS = 500000;
+		static constexpr bool WRITE_ALL_TIMES_TO_STREAM = false;
+		static constexpr bool DO_TEST = true;
+		static constexpr std::string_view NAME = "Inverse (SIMD)";
+
+		FastInverse()
+		{
+		}
+		void Prepare()
+		{
+			in_.resize(NUM_LOOPS);
+			out_.resize(NUM_LOOPS);
+			VectorFiller filler_ = VectorFiller();
+			for (std::size_t i = 0; i < NUM_LOOPS; ++i)
+			{
+				in_[i] = in_[i].Mutate(filler_);
+				out_[i] = out_[i].Mutate(filler_);
+			}
+		}
+		void operator()(std::size_t i)
+		{
+			EmuMath::FastMatrix4x4f_CM(in_[i]).Inverse().Store(out_[i]);
+		}
+		void OnTestsOver()
+		{
+			std::size_t i = static_cast<std::size_t>(rand()) % NUM_LOOPS;
+			std::cout << in_[i] << "\nINVERSE:\n" << out_[i] << "\n\n\n";
+		}
+
+		std::vector<EmuMath::Matrix<4, 4, float, true>> in_;
+		std::vector<EmuMath::Matrix<4, 4, float, true>> out_;
+	};
+
 	using AllTests = std::tuple
 	<
-		MatEmu,
-		MatDXM
+		ScalarInverseLaplace,
+		ScalarInverseGaussJordan,
+		FastInverse
 	>;
 
 

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -285,7 +285,7 @@ int main()
 	).DeterminantLaplace();
 	EmuMath::FastMatrix4x4f_CM bad_det_test_ = EmuMath::FastMatrix4x4f_CM
 	(
-		1, 2, 3533, 4,
+		1, 2, 353, 4,
 		5, 611, 7, 8,
 		9, 10, 121, 12,
 		13, 14, 115, 16
@@ -320,6 +320,19 @@ int main()
 	std::cout << bad_det_test_.Inverse().Inverse().Inverse().Inverse().Inverse() << "\n\n";
 	std::cout << bad_det_test_.Inverse().Inverse().Inverse().Inverse().Inverse().Inverse().Inverse() << "\n\n";
 	std::cout << bad_det_test_.Inverse().Inverse().Inverse().Inverse().Inverse().Inverse().Inverse().Inverse().Inverse() << "\n\n";
+
+	EmuMath::Matrix4x4<float> mat_4x4_scalar_
+	(
+		1, 12, 13, 4,
+		4, 13, 12, 1,
+		6, 3, 2, 1,
+		1, 3, 5, 5
+	);
+	std::cout << mat_4x4_scalar_ << "\n";
+	float test_output_det_;
+	std::cout << "Inv (Laplace):\n" << mat_4x4_scalar_.InverseLaplace(test_output_det_) << "\nDeterminant: " << test_output_det_ << "\n";
+	std::cout << "Inv (Gauss Jordan):\n" << mat_4x4_scalar_.InverseGaussJordan(test_output_det_) << "\nDeterminant: " << test_output_det_ << "\n";
+	std::cout << "Inv (Gauss Jordan : long double):\n" << mat_4x4_scalar_.InverseGaussJordan<long double>(test_output_det_) << "\nDeterminant: " << test_output_det_ << "\n";
 
 #pragma region TEST_HARNESS_EXECUTION
 	system("pause");


### PR DESCRIPTION
As per the previous merge, this final merge provides an implementation of Gauss-Jordan elimination to calculate an inverse of an arbitrarily sized square template matrix.

Taken verbatim from the commit implementing it:

---

Scalar template matrices were tested for inverse with 10x10 matrices:

Old laplace expansion took 150 minutes
New gauss-jordan elimination took 772 milliseconds

Laplace expansion is of time complexity O(n!), whereas gauss-jordan is O(n\*n\*n). This makes gauss-jordan less time-complex than laplace expansion in cases where the matrix is of size `6x6` or greater (note that inverses only work on square matrices, so this is always the complexity for an `nxn` matrix).

Laplace expansion could likely be optimised, but due to the generic nature of scalar matrices it would be detrimental to the program's readability to try to add optimisations to this. Some minor changes have been provided, however, such as introducing scopes to deallocate submatrices before calculating a next element's determinant, to allow more to be done without overflowing the stack.
- Despite this, larger matrices where the stack (or in some cases, the compiler heap too!) cannot  satisfy memory requirements either at runtime or compile time start rather early (for example, a 20x20 matrix will cause the compiler to run out of heap space on my system when using laplace expansion, whereas gauss-jordan can easily reach 30x30 matrices at least) are highly recommended to use gauss-jordan.
- Laplace expansion has not been removed as it is still more effective for smaller matrices, with the line drawing an equal at roughly 4x4 matrices (with laplace expansion gaining the upper hand more often than not, but these differences are typically negligible).
- SIMD matrices are unchanged