### PR TITLE
Matrix update construction

### DIFF
--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeComparators.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeComparators.h
@@ -427,6 +427,32 @@ namespace EmuCore::TMP
 	};
 	template<template<class...> class Template_, class...TypeArgs_>
 	static constexpr bool valid_template_args_v = valid_template_args<Template_, TypeArgs_...>::value;
+
+	template<class T_>
+	struct is_integer_sequence
+	{
+		static constexpr bool value = false;
+	};
+	template<class T_, T_...Vals_>
+	struct is_integer_sequence<std::integer_sequence<T_, Vals_...>>
+	{
+		static constexpr bool value = true;
+	};
+	template<class T_>
+	static constexpr bool is_integer_sequence_v = is_integer_sequence<T_>::value;
+
+	template<class T_>
+	struct is_index_sequence
+	{
+		static constexpr bool value = false;
+	};
+	template<std::size_t...Vals_>
+	struct is_index_sequence<std::index_sequence<Vals_...>>
+	{
+		static constexpr bool value = true;
+	};
+	template<class T_>
+	static constexpr bool is_index_sequence_v = is_index_sequence<T_>::value;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
@@ -432,14 +432,14 @@ namespace EmuCore::TMP
 	/// <param name="ref_">Reference to cast to an lvalue reference.</param>
 	/// <returns>The passed ref_ cast to an lvalue reference.</returns>
 	template<typename T_>
-	[[nodiscard]] constexpr inline std::add_lvalue_reference_t<T_> lval_ref_cast(std::remove_reference_t<T_>& ref_)
+	[[nodiscard]] constexpr inline std::remove_reference_t<T_>& lval_ref_cast(std::remove_reference_t<T_>& ref_)
 	{
 		return ref_;
 	}
 	template<typename T_>
-	[[nodiscard]] constexpr inline std::add_lvalue_reference_t<T_> lval_ref_cast(std::remove_reference_t<T_>&& ref_)
+	[[nodiscard]] constexpr inline std::remove_reference_t<T_>& lval_ref_cast(std::remove_reference_t<T_>&& ref_)
 	{
-		return static_cast<std::add_lvalue_reference_t<T_>>(ref_);
+		return static_cast<std::remove_reference_t<T_>&>(ref_);
 	}
 
 	/// <summary> Type used to alias type T_ as its internal type alias. Mainly for use in conditions such as `std::conditional_t&lt;bool, x, y&gt;::type`. </summary>

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
@@ -491,6 +491,15 @@ namespace EmuCore::TMP
 
 	template<typename T_>
 	using floating_point_equivalent_t = typename floating_point_equivalent<T_>::type;
+
+	/// <summary> Determines the type that results from a call to std::forward on a declval of type T_. </summary>
+	template<typename T_>
+	struct forward_result
+	{
+		using type = decltype(std::forward<T_>(std::declval<T_>()));
+	};
+	template<typename T_>
+	using forward_result_t = typename forward_result<T_>::type;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
@@ -83,6 +83,17 @@ namespace EmuCore::TMP
 	using type_and_discard_t = typename type_and_discard<T_, Discarded_>::type;
 
 	/// <summary>
+	/// <para> Variant of type_and_discard which instead takes a non-type Discarded_ argument. </para>
+	/// </summary>
+	template<class T_, auto Discarded_>
+	struct type_and_discard_val
+	{
+		using type = T_;
+	};
+	template<class T_, auto Discarded_>
+	using type_and_discard_val_t = typename type_and_discard_val<T_, Discarded_>::type;
+
+	/// <summary>
 	/// <para> Extracts the first argument type of a selection of variadic Args_, aliasing it as the internal type. </para>
 	/// <para> If 1 or more arguments are provided: type will be the first provided type. </para>
 	/// <para> If 0 arguments are provided: type will be void. </para>

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
@@ -132,7 +132,21 @@ namespace EmuCore::TMP
 	template<bool First_, bool...Remaining_>
 	struct variadic_and<First_, Remaining_...>
 	{
-		static constexpr bool value = First_ ? variadic_and<Remaining_...>::value : false;
+	private:
+		[[nodiscard]] static constexpr inline bool _get()
+		{
+			if constexpr (First_)
+			{
+				return variadic_and<Remaining_...>::value;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+	public:
+		static constexpr bool value = _get();
 	};
 	template<bool First_>
 	struct variadic_and<First_>
@@ -245,54 +259,130 @@ namespace EmuCore::TMP
 	using make_offset_index_sequence = typename offset_integer_sequence_maker<std::size_t, Offset_, Size_>::type;
 
 	/// <summary>
-	///	<para> Type used to splice to index sequences into a single one. Indices in the left-hand sequence will all appear first, then those in the right-hand sequence. </para>
-	/// <para> If an argument is not a std::index_sequence, it will be interpreted as an empty std::index_sequence. </para>
+	///	<para> Type used to splice two integer sequences into a single one. Indices in the left-hand sequence will all appear first, then those in the right-hand sequence. </para>
+	/// <para> If an argument is not a std::intger_sequence, it will be interpreted as an empty std::integer_sequence of the correct type. </para>
+	/// <para> If both arguments are not a std::intger_sequence, type will be an empty std::integer_sequence of chars. </para>
+	/// <para> If both arguments are std::integer_sequences (as they should be), the value_type of the left-hand integer sequence will be used. </para>
 	/// </summary>
-	template<class LhsIndexSequence_, class RhsIndexSequence_>
-	struct splice_index_sequences
+	template<class LhsIntegerSequence_, class RhsIntegerSequence_>
+	struct splice_integer_sequences
 	{
-		using type = std::index_sequence<>;
+	private:
+		template<class Lhs_, class Rhs_>
+		struct _builder
+		{
+			using type = std::integer_sequence<char>;
+		};
+
+		template<class LhsT_, std::size_t...LhsIndices_, class Rhs_>
+		struct _builder<std::integer_sequence<LhsT_, LhsIndices_...>, Rhs_>
+		{
+			using type = std::integer_sequence<LhsT_, LhsIndices_...>;
+		};
+
+		template<class Lhs_, class RhsT_, std::size_t...RhsIndices_>
+		struct _builder<Lhs_, std::integer_sequence<RhsT_, RhsIndices_...>>
+		{
+			using type = std::integer_sequence<RhsT_, RhsIndices_...>;
+		};
+
+	public:
+		using type = typename _builder<LhsIntegerSequence_, RhsIntegerSequence_>::type;
 	};
-	template<std::size_t...LhsIndices_, class Rhs_>
-	struct splice_index_sequences<std::index_sequence<LhsIndices_...>, Rhs_>
+	template<typename LhsT_, std::size_t...LhsIndices_, typename RhsT_, std::size_t...RhsIndices_>
+	struct splice_integer_sequences<std::integer_sequence<LhsT_, LhsIndices_...>, std::integer_sequence<RhsT_, RhsIndices_...>>
 	{
-		using type = std::index_sequence<LhsIndices_...>;
-	};
-	template<class Lhs_, std::size_t...RhsIndices_>
-	struct splice_index_sequences<Lhs_, std::index_sequence<RhsIndices_...>>
-	{
-		using type = std::index_sequence<RhsIndices_...>;
-	};
-	template<std::size_t...LhsIndices_, std::size_t...RhsIndices_>
-	struct splice_index_sequences<std::index_sequence<LhsIndices_...>, std::index_sequence<RhsIndices_...>>
-	{
-		using type = std::index_sequence<LhsIndices_..., RhsIndices_...>;
+		using type = std::integer_sequence<LhsT_, LhsIndices_..., static_cast<LhsT_>(RhsIndices_)...>;
 	};
 	template<class Lhs_, class Rhs_>
-	using splice_index_sequences_t = typename splice_index_sequences<Lhs_, Rhs_>::type;
+	using splice_index_sequences_t = typename splice_integer_sequences<Lhs_, Rhs_>::type;
 
-	/// <summary> Type used to form an index sequence containing only the specified Index_ the specified Count_ of times. </summary>
-	template<std::size_t Index_, std::size_t Count_>
-	struct duplicated_index_sequence
+	/// <summary>
+	/// <para> Type extension of splice_index_sequences which may be used to splice a variadic number of integer sequences. </para>
+	/// <para> If an argument is not a std::integer_sequence, it will be interpreted as an empty std::integer_sequence of chars. </para>
+	/// </summary>
+	template<class...IntegerSequences_>
+	struct variadic_splice_integer_sequences
 	{
-		using type = typename splice_index_sequences
+		using type = std::integer_sequence<char>;
+	};
+	template<typename T_, T_...Indices_>
+	struct variadic_splice_integer_sequences<std::integer_sequence<T_, Indices_...>>
+	{
+		using type = std::index_sequence<Indices_...>;
+	};
+	template<class LhsIndexSequence_, class RhsIndexSequence_>
+	struct variadic_splice_integer_sequences<LhsIndexSequence_, RhsIndexSequence_>
+	{
+		using type = typename splice_integer_sequences<LhsIndexSequence_, RhsIndexSequence_>::type;
+	};
+	template<class FirstIndexSequence_, class SecondIndexSequence_, class...RemainingIndexSequences_>
+	struct variadic_splice_integer_sequences<FirstIndexSequence_, SecondIndexSequence_, RemainingIndexSequences_...>
+	{
+		using type = typename variadic_splice_integer_sequences
 		<
-			std::index_sequence<Index_>,
-			typename duplicated_index_sequence<Index_, Count_ - 1>::type
+			typename splice_integer_sequences<FirstIndexSequence_, SecondIndexSequence_>::type,
+			RemainingIndexSequences_...
 		>::type;
 	};
-	template<std::size_t Index_>
-	struct duplicated_index_sequence<Index_, 0>
+	template<class...IntegerSequences_>
+	using variadic_splice_integer_sequences_t = typename variadic_splice_integer_sequences<IntegerSequences_...>::type;
+
+	/// <summary> Type used to form an index sequence containing only the specified Index_ the specified Count_ of times. </summary>
+	template<typename T_, T_ Index_, std::size_t Count_>
+	struct duplicated_integer_sequence
+	{
+		using type = typename splice_integer_sequences
+		<
+			std::index_sequence<Index_>,
+			typename duplicated_integer_sequence<T_, Index_, Count_ - 1>::type
+		>::type;
+	};
+	template<typename T_, T_ Index_>
+	struct duplicated_integer_sequence<T_, Index_, 0>
 	{
 		using type = std::index_sequence<>;
 	};
-	template<std::size_t Index_>
-	struct duplicated_index_sequence<Index_, 1>
+	template<typename T_, T_ Index_>
+	struct duplicated_integer_sequence<T_, Index_, 1>
 	{
-		using type = std::index_sequence<Index_>;
+		using type = std::integer_sequence<T_, Index_>;
 	};
 	template<std::size_t Index_, std::size_t Count_>
-	using make_duplicated_index_sequence = typename duplicated_index_sequence<Index_, Count_>::type;
+	using make_duplicated_index_sequence = typename duplicated_integer_sequence<std::size_t, Index_, Count_>::type;
+
+	/// <summary> Type used to form an integer sequence which consists of the provided sequence looped the specified number of times. </summary>
+	template<class IntegerSequence_, std::size_t LoopCount_>
+	struct looped_integer_sequence
+	{
+		using type = std::integer_sequence<char>;
+	};
+	template<typename T_, T_...Indices_, std::size_t LoopCount_>
+	struct looped_integer_sequence<std::integer_sequence<T_, Indices_...>, LoopCount_>
+	{
+	private:
+		using _base_sequence = std::integer_sequence<T_, Indices_...>;
+
+		template<class CurrentSequence_, std::size_t RemainingLoops_>
+		struct _sequence_builder
+		{
+			using type = typename _sequence_builder
+			<
+				typename splice_integer_sequences<CurrentSequence_, _base_sequence>::type,
+				RemainingLoops_ - 1
+			>::type;
+		};
+		template<class CurrentSequence_>
+		struct _sequence_builder<CurrentSequence_, 0>
+		{
+			using type = CurrentSequence_;
+		};
+
+	public:
+		using type = typename _sequence_builder<_base_sequence, LoopCount_>::type;
+	};
+	template<class IntegerSequence_, std::size_t LoopCount_>
+	using make_looped_integer_sequence = typename looped_integer_sequence<IntegerSequence_, LoopCount_>::type;
 
 	/// <summary>
 	/// <para> Helper type to perform a comparison of all constants to determine the last to compare true. </para>

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/VariadicHelpers.h
@@ -81,6 +81,34 @@ namespace EmuCore::TMP
 	};
 	template<class T_, class Discarded_>
 	using type_and_discard_t = typename type_and_discard<T_, Discarded_>::type;
+
+	/// <summary>
+	/// <para> Extracts the first argument type of a selection of variadic Args_, aliasing it as the internal type. </para>
+	/// <para> If 1 or more arguments are provided: type will be the first provided type. </para>
+	/// <para> If 0 arguments are provided: type will be void. </para>
+	/// </summary>
+	template<class...Args_>
+	struct first_variadic_arg
+	{
+		using type = void;
+	};
+	template<class First_, class...Others_>
+	struct first_variadic_arg<First_, Others_...>
+	{
+		using type = First_;
+	};
+	template<class First_>
+	struct first_variadic_arg<First_>
+	{
+		using type = First_;
+	};
+	template<>
+	struct first_variadic_arg<>
+	{
+		using type = void;
+	};
+	template<class...Args_>
+	using first_variadic_arg_t = typename first_variadic_arg<Args_...>::type;
 #pragma endregion
 
 #pragma region VARIADIC_BOOLS

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="EmuMath\Random.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_all_matrix_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_common_matrix_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_stream_append.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_matrix_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix.info.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -184,10 +184,12 @@
     <ClInclude Include="EmuMath\Random.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_all_matrix_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_common_matrix_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_copy.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_stream_append.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_matrix_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix.info.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_copy.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_stream_append.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_tmp.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_stream_append.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_matrix_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix.info.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_stream_append.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_noise\_noise_gen_functors\_simd_noise_gen_1d.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -476,5 +476,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_all_matrix_helpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_get.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -482,5 +482,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_get.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_copy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_copy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -479,5 +479,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_get.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_get.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_ALL_MATRIX_HELPERS_H_INC_ 1
 
 #include "_common_matrix_helper_includes.h"
+#include "_matrix_get.h"
 #include "_matrix_stream_append.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_ALL_MATRIX_HELPERS_H_INC_ 1
 
 #include "_common_matrix_helper_includes.h"
+#include "_matrix_copy.h"
 #include "_matrix_get.h"
 #include "_matrix_stream_append.h"
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
@@ -3,6 +3,7 @@
 
 #include "../_underlying_helpers/_matrix.info.h"
 #include "../_underlying_helpers/_matrix_tmp.h"
+#include "../_underlying_helpers/_matrix_underlying_get.h"
 #include "../_underlying_helpers/_matrix_underlying_stream_append.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
@@ -3,6 +3,7 @@
 
 #include "../_underlying_helpers/_matrix.info.h"
 #include "../_underlying_helpers/_matrix_tmp.h"
+#include "../_underlying_helpers/_matrix_underlying_copy.h"
 #include "../_underlying_helpers/_matrix_underlying_get.h"
 #include "../_underlying_helpers/_matrix_underlying_stream_append.h"
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_copy.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_copy.h
@@ -1,0 +1,436 @@
+#ifndef EMU_MATH_MATRIX_COPY_H_INC_
+#define EMU_MATH_MATRIX_COPY_H_INC_ 1
+
+#include "_common_matrix_helper_includes.h"
+
+// CONTAINS:
+// --- copy_is_valid
+// --- copy (non-const reference)
+// --- copy (const reference)
+// --- copy (non-const move-or-copy)
+// --- copy (const move-or-copy)
+
+namespace EmuMath::Helpers
+{
+#pragma region COPY_IS_VALID_FUNCS
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		class InMatrix_,
+		typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<InMatrix_>>
+	>
+	[[nodiscard]] constexpr inline bool matrix_copy_is_valid()
+	{
+		using out_matrix_type = EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>;
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_matrix_type>;
+		return _matrix_underlying::_matrix_create_from_matrix_is_valid
+		<
+			out_matrix_type,
+			InMatrix_,
+			false
+		>(typename out_indices::column_index_sequence(), typename out_indices::row_index_sequence());
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		class InMatrix_,
+		typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<InMatrix_>>
+	>
+	[[nodiscard]] constexpr inline bool matrix_assert_copy_is_valid()
+	{
+		using out_matrix_type = EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>;
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_matrix_type>;
+		return _matrix_underlying::_matrix_create_from_matrix_is_valid
+		<
+			out_matrix_type,
+			InMatrix_,
+			true
+		>(typename out_indices::column_index_sequence(), typename out_indices::row_index_sequence());
+	}
+#pragma endregion
+
+#pragma region NON_CONST_REF_COPY_FUNCS
+	/// <summary>
+	/// <para> Produces an EmuMath Matrix which copies the respective indices of the provided in_matrix_. </para>
+	/// <para> OutNumColumns_ and OutNumRows_: Number of columns and rows (respectively) for the output Matrix to contain. Default to those of in_matrix_ if not provided. </para>
+	/// <para> OutT_: T_ argument for the output Matrix. Defaults to the value_type_uq of in_matrix_ if not provided. </para>
+	/// <para> OutColumnMajor_: ColumnMajor_ argument for the output Matrix. Defaults to that of in_matrix_ if not provided. </para>
+	/// </summary>
+	/// <param name="in_matrix_">: Non-const reference to an EmuMath Matrix to copy.</param>
+	/// <returns>Copy of the provided input EmuMath Matrix, as the desired type of EmuMath Matrix.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_>(in_matrix_);
+	}
+
+	template<typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, InColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, InColumnMajor_>(in_matrix_);
+	}
+
+	template<typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		InNumColumns_,
+		InNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, in_value_uq, InColumnMajor_>(in_matrix_);
+	}
+#pragma endregion
+
+#pragma region CONST_REF_COPY_FUNCS
+	/// <summary>
+	/// <para> Produces an EmuMath Matrix which copies the respective indices of the provided in_matrix_. </para>
+	/// <para> OutNumColumns_ and OutNumRows_: Number of columns and rows (respectively) for the output Matrix to contain. Default to those of in_matrix_ if not provided. </para>
+	/// <para> OutT_: T_ argument for the output Matrix. Defaults to the value_type_uq of in_matrix_ if not provided. </para>
+	/// <para> OutColumnMajor_: ColumnMajor_ argument for the output Matrix. Defaults to that of in_matrix_ if not provided. </para>
+	/// </summary>
+	/// <param name="in_matrix_">: Const reference to an EmuMath Matrix to copy.</param>
+	/// <returns>Copy of the provided input EmuMath Matrix, as the desired type of EmuMath Matrix.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, OutColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_>(in_matrix_);
+	}
+
+	template<typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, InColumnMajor_>(in_matrix_);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, InColumnMajor_>(in_matrix_);
+	}
+
+	template<typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		InNumColumns_,
+		InNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>& in_matrix_)
+	{
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, in_value_uq, InColumnMajor_>(in_matrix_);
+	}
+#pragma endregion
+
+#pragma region NON_CONST_MOVE_COPY_FUNCS
+	/// <summary>
+	/// <para> Produces an EmuMath Matrix which moves or copies the respective indices of the provided in_matrix_. </para>
+	/// <para> OutNumColumns_ and OutNumRows_: Number of columns and rows (respectively) for the output Matrix to contain. Default to those of in_matrix_ if not provided. </para>
+	/// <para> OutT_: T_ argument for the output Matrix. Defaults to the value_type_uq of in_matrix_ if not provided. </para>
+	/// <para> OutColumnMajor_: ColumnMajor_ argument for the output Matrix. Defaults to that of in_matrix_ if not provided. </para>
+	/// </summary>
+	/// <param name="in_matrix_">: Non-const rvalue-reference to an EmuMath Matrix to move-or-copy.</param>
+	/// <returns>Copy of the provided input EmuMath Matrix, as the desired type of EmuMath Matrix.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		InNumColumns_,
+		InNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, in_value_uq, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+#pragma endregion
+
+#pragma region CONST_MOVE_COPY_FUNCS
+	/// <summary>
+	/// <para> Produces an EmuMath Matrix which moves or copies the respective indices of the provided in_matrix_. </para>
+	/// <para> OutNumColumns_ and OutNumRows_: Number of columns and rows (respectively) for the output Matrix to contain. Default to those of in_matrix_ if not provided. </para>
+	/// <para> OutT_: T_ argument for the output Matrix. Defaults to the value_type_uq of in_matrix_ if not provided. </para>
+	/// <para> OutColumnMajor_: ColumnMajor_ argument for the output Matrix. Defaults to that of in_matrix_ if not provided. </para>
+	/// </summary>
+	/// <param name="in_matrix_">: Const rvalue-reference to an EmuMath Matrix to move-or-copy.</param>
+	/// <returns>Copy of the provided input EmuMath Matrix, as the desired type of EmuMath Matrix.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, OutColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, OutT_, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename OutT_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<InNumColumns_, InNumRows_, OutT_, InColumnMajor_> matrix_copy
+	(
+		const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_
+	)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, OutT_, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<OutNumColumns_, OutNumRows_, in_value_uq, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+
+	template<typename InT_, std::size_t InNumColumns_, std::size_t InNumRows_, bool InColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		InNumColumns_,
+		InNumRows_,
+		typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq,
+		InColumnMajor_
+	>
+	matrix_copy(const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>&& in_matrix_)
+	{
+		using in_matrix_type = const EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>;
+		using in_value_uq = typename EmuMath::Matrix<InNumColumns_, InNumRows_, InT_, InColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_copy<InNumColumns_, InNumRows_, in_value_uq, InColumnMajor_>(std::forward<in_matrix_type>(in_matrix_));
+	}
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
@@ -6,6 +6,99 @@
 namespace EmuMath::Helpers
 {
 	/// <summary>
+	/// <para> Outputs an implied-zero value that all non-contained elements of the provided Matrix_ type will be interpreted as. </para>
+	/// </summary>
+	/// <returns>
+	///		A value of Matrix_'s value_type_uq type, default constructed, constructed with an argument of 0, 
+	///		or constructed with an argument of 0.0f, whichever is possible and earliest in the listed order.
+	/// </returns>
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename EmuCore::TMP::remove_ref_cv_t<Matrix_>::value_type_uq matrix_get_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_non_contained<Matrix_>();
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq matrix_get_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	/// <summary>
+	/// <para> Outputs an implied-zero Vector representing a non-contained column of the provided Matrix_ type. </para>
+	/// </summary>
+	/// <returns>
+	///		By default, a Vector the same size as the passed Matrix_'s columns, containing value_type_uq elements that are default constructed, 
+	///		constructed with an argument of 0, or constructed with an argument of 0.0f, whichever is possible and earliest in the listed order.
+	/// </returns>
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_column<Matrix_>::type matrix_get_column_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_column_non_contained<Matrix_>();
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_column<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>::type
+	matrix_get_column_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_column_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	/// <summary>
+	/// <para> Outputs an implied-zero Vector representing a non-contained row of the provided Matrix_ type. </para>
+	/// </summary>
+	/// <returns>
+	///		By default, a Vector the same size as the passed Matrix_'s rows, containing value_type_uq elements that are default constructed, 
+	///		constructed with an argument of 0, or constructed with an argument of 0.0f, whichever is possible and earliest in the listed order.
+	/// </returns>
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_row<Matrix_>::type matrix_get_row_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_row_non_contained<Matrix_>();
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_row<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>::type
+	matrix_get_row_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_row_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	/// <summary>
+	/// <para> Outputs an implied-zero Vector representing a non-contained major element of the provided Matrix_ type. </para>
+	/// </summary>
+	/// <returns> If Matrix_ is column-major, the same as matrix_get_column_non_contained. Otherwise, the same as matrix_get_row_non_contained. </returns>
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline decltype(_matrix_underlying::_matrix_get_major_non_contained<Matrix_>()) matrix_get_major_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_major_non_contained<Matrix_>();
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline decltype(_matrix_underlying::_matrix_get_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>())
+	matrix_get_major_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	/// <summary>
+	/// <para> Outputs an implied-zero Vector representing a non-contained non-major element of the provided Matrix_ type. </para>
+	/// </summary>
+	/// <returns> If Matrix_ is column-major, the same as matrix_get_row_non_contained. Otherwise, the same as matrix_get_column_non_contained. </returns>
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline decltype(_matrix_underlying::_matrix_get_non_major_non_contained<Matrix_>()) matrix_get_non_major_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_non_major_non_contained<Matrix_>();
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline decltype(_matrix_underlying::_matrix_get_non_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>())
+	matrix_get_non_major_non_contained()
+	{
+		return _matrix_underlying::_matrix_get_non_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	/// <summary>
 	/// <para> Accesses a reference to the element at the provided column+row index of the passed matrix_. </para>
 	/// <para> If a non-contained index may attempt to be accessed (and this is intended behaviour), one should use `matrix_get_theoretical` instead. </para>
 	/// </summary>
@@ -27,6 +120,25 @@ namespace EmuMath::Helpers
 	)
 	{
 		return _matrix_underlying::_matrix_get<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses either a reference to the element at the provided column+row index of the passed matrix_, or an implied-zero value_type_uq of the Matrix type. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified theoretical element of.</param>
+	/// <returns>Reference to the element at the provided column+row index within the passed Matrix_ if the index is contained, otherwise an implied-zero value_type_uq.</returns>
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
 	}
 
 	/// <summary>
@@ -58,25 +170,6 @@ namespace EmuMath::Helpers
 	}
 
 	/// <summary>
-	/// <para> Accesses either a reference to the element at the provided column+row index of the passed matrix_, or an implied-zero value_type_uq of the Matrix type. </para>
-	/// </summary>
-	/// <param name="matrix_">: EmuMath Matrix to access the specified theoretical element of.</param>
-	/// <returns>Reference to the element at the provided column+row index within the passed Matrix_ if the index is contained, otherwise an implied-zero value_type_uq.</returns>
-	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
-	matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
-	{
-		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
-	}
-
-	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
-	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
-	matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
-	{
-		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
-	}
-
-	/// <summary>
 	/// <para> Accesses either a reference to the element at the provided flattened index of the passed matrix_, or an implied-zero value_type_uq of the Matrix type. </para>
 	/// <para>
 	///		The flattened index is always interpreted as column-major, where index (x + 1) is the next item in a column after x,
@@ -97,6 +190,220 @@ namespace EmuMath::Helpers
 	matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
 	{
 		return _matrix_underlying::_matrix_get_theoretical<FlattenedIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the column at the provided ColumnIndex_ within the passed matrix_. </para>
+	/// <para> If matrix_ is column-major: This will be a direct reference to the specified column. </para>
+	/// <para> If matrix_ is not column-major: This will be an EmuMath Vector of references to elements at respective points within the specified column. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified column of.</param>
+	/// <returns>EmuMath Vector referencing the specified column within the passed matrix_.</returns>
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::column_get_ref_type matrix_get_column
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_column<ColumnIndex_>(matrix_);
+	}
+
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::column_get_const_ref_type matrix_get_column
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_column<ColumnIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the theoretical column at the provided ColumnIndex_ within the passed matrix_. </para>
+	/// <para> If matrix_ is column-major and the index is contained: This will be a direct reference to the specified column. </para>
+	/// <para> 
+	///		If matrix_ is not column-major and the index is contained: This will be an EmuMath Vector of references to elements at respective points within the specified column. 
+	/// </para>
+	/// <para> If the index is not contained: This will be an implied-zero column for the type of matrix_. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified column of.</param>
+	/// <returns>EmuMath Vector referencing the specified column within the passed matrix_, or an implied-zero column if the index is not contained.</returns>
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_column_theoretical
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_column_theoretical<ColumnIndex_>(matrix_);
+	}
+
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_column_theoretical
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_column_theoretical<ColumnIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the column at the provided RowIndex_ within the passed matrix_. </para>
+	/// <para> If matrix_ is column-major: This will be a direct reference to the specified column. </para>
+	/// <para> If matrix_ is not column-major: This will be an EmuMath Vector of references to elements at respective points within the specified column. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified row of.</param>
+	/// <returns>EmuMath Vector referencing the specified row within the passed matrix_.</returns>
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::row_get_ref_type matrix_get_row
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_row<RowIndex_>(matrix_);
+	}
+
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::row_get_const_ref_type matrix_get_row
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_row<RowIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the theoretical row at the provided RowIndex_ within the passed matrix_. </para>
+	/// <para> If matrix_ is column-major and the index is contained: This will be an EmuMath Vector of references to elements at respective points within the specified row. </para>
+	/// <para> If matrix_ is not column-major and the index is contained: This will be a direct reference to the specified row. </para>
+	/// <para> If the index is not contained: This will be an implied-zero row for the type of matrix_. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified row of.</param>
+	/// <returns>EmuMath Vector referencing the specified row within the passed matrix_, or an implied-zero row if the index is not contained.</returns>
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_row_theoretical
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_row_theoretical<RowIndex_>(matrix_);
+	}
+
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_row_theoretical
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_row_theoretical<RowIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the major element at the provided MajorIndex_ within the passed matrix_. </para>
+	/// <para> If the passed matrix_ is column-major: This will be a reference to the column at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is not column-major: This will be a reference to the row at the specified MajorIndex_. </para>
+	/// </summary>
+	/// <returns>EmuMath Vector referencing the specified major element within the passed matrix_.</returns>
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::major_get_ref_type matrix_get_major
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_major<MajorIndex_>(matrix_);
+	}
+
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::major_get_const_ref_type matrix_get_major
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_major<MajorIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the theoretical major element at the provided MajorIndex_ within the passed matrix_. </para>
+	/// <para> If the passed matrix_ is column-major and the index is contained: This will be a reference to the column at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is not column-major and the index is contained: This will be a reference to the row at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is column-major and the index is not contained: This will be an implied-zero column for the provided matrix_. </para>
+	/// <para> If the passed matrix_ is not column-major and the index is not contained: This will be an implied-zero row for the provided matrix_. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified major element of.</param>
+	/// <returns>EmuMath Vector referencing the specified major element within the passed matrix_, or an implied-zero non-major element if it is not contained.</returns>
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_major_theoretical
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_major_theoretical<MajorIndex_>(matrix_);
+	}
+
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_major_theoretical
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_major_theoretical<MajorIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the non-major element at the provided NonMajorIndex_ within the passed matrix_. </para>
+	/// <para> If the passed matrix_ is column-major: This will be a reference to the row at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is not column-major: This will be a reference to the column at the specified MajorIndex_. </para>
+	/// </summary>
+	/// <returns>EmuMath Vector referencing the specified non-major element within the passed matrix_.</returns>
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::non_major_get_ref_type matrix_get_non_major
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_non_major<NonMajorIndex_>(matrix_);
+	}
+
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::non_major_get_const_ref_type matrix_get_non_major
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_non_major<NonMajorIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses the theoretical non-major element at the provided NonMajorIndex_ within the passed matrix_. </para>
+	/// <para> If the passed matrix_ is column-major and the index is contained: This will be a reference to the row at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is not column-major and the index is contained: This will be a reference to the column at the specified MajorIndex_. </para>
+	/// <para> If the passed matrix_ is column-major and the index is not contained: This will be an implied-zero row for the provided matrix_. </para>
+	/// <para> If the passed matrix_ is not column-major and the index is not contained: This will be an implied-zero column for the provided matrix_. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified non-major element of.</param>
+	/// <returns>EmuMath Vector referencing the specified non-major element within the passed matrix_, or an implied-zero non-major element if it is not contained.</returns>
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_non_major_theoretical
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_non_major_theoretical<NonMajorIndex_>(matrix_);
+	}
+
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_non_major_theoretical
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get_non_major_theoretical<NonMajorIndex_>(matrix_);
 	}
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
@@ -1,0 +1,103 @@
+#ifndef EMU_MATH_MATRIX_GET_H_INC_
+#define EMU_MATH_MATRIX_GET_H_INC_ 1
+
+#include "_common_matrix_helper_includes.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Accesses a reference to the element at the provided column+row index of the passed matrix_. </para>
+	/// <para> If a non-contained index may attempt to be accessed (and this is intended behaviour), one should use `matrix_get_theoretical` instead. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified element of.</param>
+	/// <returns>Reference to the element at the provided column and row index within the passed Matrix.</returns>
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& matrix_get
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline const typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& matrix_get
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses a reference to the element at the provided flattened index of the passed matrix_. </para>
+	/// <para>
+	///		The flattened index is always interpreted as column-major, where index (x + 1) is the next item in a column after x,
+	///		or the start of the next column if x is the final index of a column.
+	/// </para>
+	/// <para> If a non-contained index may attempt to be accessed (and this is intended behaviour), one should use `matrix_get_theoretical` instead. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified element of.</param>
+	/// <returns>Reference to the element at the provided flattened index within the passed Matrix.</returns>
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& matrix_get
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get<FlattenedIndex_>(matrix_);
+	}
+
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline const typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& matrix_get
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return _matrix_underlying::_matrix_get<FlattenedIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses either a reference to the element at the provided column+row index of the passed matrix_, or an implied-zero value_type_uq of the Matrix type. </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified theoretical element of.</param>
+	/// <returns>Reference to the element at the provided column+row index within the passed Matrix_ if the index is contained, otherwise an implied-zero value_type_uq.</returns>
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<ColumnIndex_, RowIndex_>(matrix_);
+	}
+
+	/// <summary>
+	/// <para> Accesses either a reference to the element at the provided flattened index of the passed matrix_, or an implied-zero value_type_uq of the Matrix type. </para>
+	/// <para>
+	///		The flattened index is always interpreted as column-major, where index (x + 1) is the next item in a column after x,
+	///		or the start of the next column if x is the final index of a column.
+	/// </para>
+	/// </summary>
+	/// <param name="matrix_">: EmuMath Matrix to access the specified theoretical element of.</param>
+	/// <returns>Reference to the element at the provided flattened index within the passed Matrix_ if the index is contained, otherwise an implied-zero value_type_uq.</returns>
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<FlattenedIndex_>(matrix_);
+	}
+
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_theoretical<FlattenedIndex_>(matrix_);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_get.h
@@ -405,6 +405,108 @@ namespace EmuMath::Helpers
 	{
 		return _matrix_underlying::_matrix_get_non_major_theoretical<NonMajorIndex_>(matrix_);
 	}
+
+	/// <summary>
+	/// <para>
+	///		Outputs an EmuMath Vector representing the main-diagonal of the provided matrix_, 
+	///		starting from the provided Offset_ for as many indices as the output Vector holds.
+	/// </para>
+	/// <para> If no OutSize_ is provided, the output size will default to that of matrix_'s smallest axis. </para>
+	/// <para> Offset_: Inclusive index from which to start reading main diagonal elements. This is used as both a column index and a row index. Defaults to 0. </para>
+	/// </summary>
+	/// <param name="matrix_">: Reference to an EmuMath Matrix to retrieve the main-diagonal of.</param>
+	/// <returns>EmuMath Vector representing the main diagonal in the passed matrix for as many elements as it contains, and starting from the provided Offset_.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> matrix_get_main_diagonal(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, OutSize_, OutT_>(matrix_);
+	}
+
+	template<std::size_t OutSize_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq> matrix_get_main_diagonal
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		using matrix_value_uq = typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, OutSize_, matrix_value_uq>(matrix_);
+	}
+
+	template<typename OutT_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>, OutT_> matrix_get_main_diagonal
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		constexpr std::size_t out_size_ = EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>;
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, out_size_, OutT_>(matrix_);
+	}
+
+	template<typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector
+	<
+		EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>,
+		typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq
+	> matrix_get_main_diagonal
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		constexpr std::size_t out_size_ = EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>;
+		using matrix_value_uq = typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_get_main_diagonal<0, out_size_, matrix_value_uq>(matrix_);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Outputs an EmuMath Vector representing the main-diagonal of the provided matrix_, 
+	///		starting from the provided Offset_ for as many indices as the output Vector holds.
+	/// </para>
+	/// <para> If no OutSize_ is provided, the output size will default to that of matrix_'s smallest axis. </para>
+	/// <para> Offset_: Inclusive index from which to start reading main diagonal elements. This is used as both a column index and a row index. Defaults to 0. </para>
+	/// </summary>
+	/// <param name="matrix_">: Const reference to an EmuMath Matrix to retrieve the main-diagonal of.</param>
+	/// <returns>EmuMath Vector representing the main diagonal in the passed matrix for as many elements as it contains, and starting from the provided Offset_.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> matrix_get_main_diagonal(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, OutSize_, OutT_>(matrix_);
+	}
+
+	template<std::size_t OutSize_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq> matrix_get_main_diagonal
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		using matrix_value_uq = typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, OutSize_, matrix_value_uq>(matrix_);
+	}
+
+	template<typename OutT_, std::size_t Offset_ = 0, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>, OutT_> matrix_get_main_diagonal
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		constexpr std::size_t out_size_ = EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>;
+		return _matrix_underlying::_matrix_get_main_diagonal<Offset_, out_size_, OutT_>(matrix_);
+	}
+
+	template<typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline EmuMath::Vector
+	<
+		EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>,
+		typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq
+	> matrix_get_main_diagonal
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		constexpr std::size_t out_size_ = EmuMath::TMP::matrix_smallest_axis_v<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>;
+		using matrix_value_uq = typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq;
+		return _matrix_underlying::_matrix_get_main_diagonal<0, out_size_, matrix_value_uq>(matrix_);
+	}
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -912,6 +912,60 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::matrix_get_non_major_theoretical<NonMajorIndex_>(*this);
 		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs an EmuMath Vector representing the main-diagonal of the this Matrix, 
+		///		starting from the provided Offset_ for as many indices as the output Vector holds.
+		/// </para>
+		/// <para> If no OutSize_ is provided, the output size will default to that of this Matrix's smallest axis. </para>
+		/// <para> Offset_: Inclusive index from which to start reading main diagonal elements. This is used as both a column index and a row index. Defaults to 0. </para>
+		/// </summary>
+		/// <returns>EmuMath Vector representing the main diagonal within this Matrix for as many elements as it contains, and starting from the provided Offset_.</returns>
+		template<std::size_t OutSize_, typename OutT_, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> MainDiagonal()
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<OutSize_, OutT_, Offset_>(*this);
+		}
+
+		template<std::size_t OutSize_, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, value_type_uq> MainDiagonal()
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<OutSize_, value_type_uq, Offset_>(*this);
+		}
+
+		template<typename OutT_ = value_type_uq, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<EmuMath::TMP::matrix_smallest_axis_v<this_type>, OutT_> MainDiagonal()
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<EmuMath::TMP::matrix_smallest_axis_v<this_type>, OutT_, Offset_>(*this);
+		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs an EmuMath Vector representing the main-diagonal of the this Matrix, 
+		///		starting from the provided Offset_ for as many indices as the output Vector holds.
+		/// </para>
+		/// <para> If no OutSize_ is provided, the output size will default to that of this Matrix's smallest axis. </para>
+		/// <para> Offset_: Inclusive index from which to start reading main diagonal elements. This is used as both a column index and a row index. Defaults to 0. </para>
+		/// </summary>
+		/// <returns>EmuMath Vector representing the main diagonal within this Matrix for as many elements as it contains, and starting from the provided Offset_.</returns>
+		template<std::size_t OutSize_, typename OutT_, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> MainDiagonal() const
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<OutSize_, OutT_, Offset_>(*this);
+		}
+
+		template<std::size_t OutSize_, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, value_type_uq> MainDiagonal() const
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<OutSize_, value_type_uq, Offset_>(*this);
+		}
+
+		template<typename OutT_ = value_type_uq, std::size_t Offset_ = 0>
+		[[nodiscard]] constexpr inline EmuMath::Vector<EmuMath::TMP::matrix_smallest_axis_v<this_type>, OutT_> MainDiagonal() const
+		{
+			return EmuMath::Helpers::matrix_get_main_diagonal<EmuMath::TMP::matrix_smallest_axis_v<this_type>, OutT_, Offset_>(*this);
+		}
 #pragma endregion
 
 #pragma region STREAM_FUNCS

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -168,7 +168,7 @@ namespace EmuMath
 	public:
 		/// <summary>
 		/// <para> Accesses the element at the provided indices within this Matrix, with compile-time validity checks. </para>
-		/// <para> If either ColumnIndex_ or RowIndex_, a static_assert will be triggered. </para>
+		/// <para> If either ColumnIndex_ or RowIndex_ is not contained, a static_assert will be triggered. </para>
 		/// </summary>
 		/// <returns>Reference to the element at the provided index within this Matrix.</returns>
 		template<std::size_t ColumnIndex_, std::size_t RowIndex_>
@@ -205,6 +205,24 @@ namespace EmuMath
 		[[nodiscard]] constexpr inline const value_type& at() const
 		{
 			return const_cast<this_type*>(this)->template at<ColumnIndex_, RowIndex_>();
+		}
+
+		/// <summary>
+		/// <para> Accesses the element at the provided indices within this Matrix, with compile-time validity checks. </para>
+		/// <para> If the provided idnex is contained, this will return a reference to the specified element. </para>
+		/// <para> If either ColumnIndex_ or RowIndex_ is not contained, this will return a newly constructed value_type_uq. </para>
+		/// </summary>
+		/// <returns>Reference to the element at the provided index within this Matrix if the index is contained, otherwise a newly constructed value_type_uq.</returns>
+		template<std::size_t ColumnIndex_, std::size_t RowIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, this_type&>::type AtTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_theoretical<ColumnIndex_, RowIndex_>(*this);
+		}
+
+		template<std::size_t ColumnIndex_, std::size_t RowIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, const this_type&>::type AtTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_theoretical<ColumnIndex_, RowIndex_>(*this);
 		}
 
 		/// <summary>
@@ -262,6 +280,24 @@ namespace EmuMath
 		[[nodiscard]] constexpr inline const value_type& at() const
 		{
 			return const_cast<this_type*>(this)->template at<FlattenedIndex_>();
+		}
+
+		/// <summary>
+		/// <para> Accesses the element at the provided indices within this Matrix, with compile-time validity checks. </para>
+		/// <para> If the provided idnex is contained, this will return a reference to the specified element. </para>
+		/// <para> If either ColumnIndex_ or RowIndex_ is not contained, this will return a newly constructed value_type_uq. </para>
+		/// </summary>
+		/// <returns>Reference to the element at the provided index within this Matrix if the index is contained, otherwise a newly constructed value_type_uq.</returns>
+		template<std::size_t FlattenedIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, this_type&>::type AtTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_theoretical<FlattenedIndex_>(*this);
+		}
+
+		template<std::size_t FlattenedIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, const this_type&>::type AtTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_theoretical<FlattenedIndex_>(*this);
 		}
 
 		/// <summary>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -136,6 +136,33 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region GENERAL_STATIC_FUNCS
+		[[nodiscard]] static constexpr inline value_type_uq get_implied_zero()
+		{
+			return EmuMath::Helpers::matrix_get_non_contained<this_type>();
+		}
+
+		[[nodiscard]] static constexpr inline typename EmuMath::TMP::matrix_non_contained_column<this_type>::type get_implied_zero_column()
+		{
+			return EmuMath::Helpers::matrix_get_column_non_contained<this_type>();
+		}
+
+		[[nodiscard]] static constexpr inline typename EmuMath::TMP::matrix_non_contained_row<this_type>::type get_implied_zero_row()
+		{
+			return EmuMath::Helpers::matrix_get_row_non_contained<this_type>();
+		}
+
+		[[nodiscard]] static constexpr inline decltype(EmuMath::Helpers::matrix_get_major_non_contained<this_type>()) get_implied_zero_major()
+		{
+			return EmuMath::Helpers::matrix_get_major_non_contained<this_type>();
+		}
+
+		[[nodiscard]] static constexpr inline decltype(EmuMath::Helpers::matrix_get_non_major_non_contained<this_type>()) get_implied_zero_non_major()
+		{
+			return EmuMath::Helpers::matrix_get_non_major_non_contained<this_type>();
+		}
+#pragma endregion
+
 #pragma region CONSTRUCTORS
 	public:
 		template<typename = std::enable_if_t<is_default_constructible()>>
@@ -500,7 +527,7 @@ namespace EmuMath
 		/// <summary>
 		/// <para> Accesses the column at the provided ColumnIndex_ within this Matrix. </para>
 		/// <para> If this Matrix is column-major: This will be a direct reference to the specified column. </para>
-		/// <para> If this Matrix is not column-major: This will be an EmuMath Vector of reference to elements at respective points within the specified column. </para>
+		/// <para> If this Matrix is not column-major: This will be an EmuMath Vector of references to elements at respective points within the specified column. </para>
 		/// </summary>
 		/// <returns>EmuMath Vector referencing the specified column within this Matrix.</returns>
 		template<std::size_t ColumnIndex_>
@@ -552,8 +579,30 @@ namespace EmuMath
 		}
 
 		/// <summary>
+		/// <para> Accesses the theoretical column at the provided ColumnIndex_ within this Matrix. </para>
+		/// <para> If this Matrix is column-major and the index is contained: This will be a direct reference to the specified column. </para>
+		/// <para> 
+		///		If this Matrix is not column-major and the index is contained: 
+		///		This will be an EmuMath Vector of references to elements at respective points within the specified column. 
+		/// </para>
+		/// <para> If the index is not contained: This will be an implied-zero column for this Matrix type. </para>
+		/// </summary>
+		/// <returns>EmuMath Vector referencing the specified column within this Matrix, or an implied-zero column if the index is not contained.</returns>
+		template<std::size_t ColumnIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, this_type&>::type GetColumnTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_column_theoretical<ColumnIndex_>(*this);
+		}
+
+		template<std::size_t ColumnIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, const this_type&>::type GetColumnTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_column_theoretical<ColumnIndex_>(*this);
+		}
+
+		/// <summary>
 		/// <para> Accesses the row at the provided RowIndex_ within this Matrix. </para>
-		/// <para> If this Matrix is column-major: This will be an EmuMath Vector of reference to elements at respective points within the specified row. </para>
+		/// <para> If this Matrix is column-major: This will be an EmuMath Vector of references to elements at respective points within the specified row. </para>
 		/// <para> If this Matrix is not column-major: This will be a direct reference to the specified row. </para>
 		/// </summary>
 		/// <returns>EmuMath Vector referencing the specified row within this Matrix.</returns>
@@ -606,7 +655,29 @@ namespace EmuMath
 		}
 
 		/// <summary>
-		/// <para> Accesses the major eement at the provided MajorIndex_ within this Matrix. </para>
+		/// <para> Accesses the theoretical row at the provided RowIndex_ within this Matrix. </para>
+		/// <para> 
+		///		If this Matrix is column-major and the index is contained: 
+		///		This will be an EmuMath Vector of references to elements at respective points within the specified row. 
+		/// </para>
+		/// <para> If this Matrix is not column-major and the index is contained: This will be a direct reference to the specified row. </para>
+		/// <para> If the index is not contained: This will be an implied-zero row for this Matrix type. </para>
+		/// </summary>
+		/// <returns>EmuMath Vector referencing the specified row within this Matrix, or an implied-zero row if the index is not contained.</returns>
+		template<std::size_t RowIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, this_type&>::type GetRowTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_row_theoretical<RowIndex_>(*this);
+		}
+
+		template<std::size_t RowIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, const this_type&>::type GetRowTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_row_theoretical<RowIndex_>(*this);
+		}
+
+		/// <summary>
+		/// <para> Accesses the major element at the provided MajorIndex_ within this Matrix. </para>
 		/// <para> If this Matrix is column-major: This will be a reference to the column at the specified MajorIndex_. </para>
 		/// <para> If this Matrix is not column-major: This will be a reference to the row at the specified MajorIndex_. </para>
 		/// </summary>
@@ -647,6 +718,26 @@ namespace EmuMath
 		}
 
 		/// <summary>
+		/// <para> Accesses the theoretical major element at the provided MajorIndex_ within this Matrix. </para>
+		/// <para> If this Matrix is column-major and the index is contained: This will be a reference to the column at the specified MajorIndex_. </para>
+		/// <para> If this Matrix is not column-major and the index is contained: This will be a reference to the row at the specified MajorIndex_. </para>
+		/// <para> If this Matrix is column-major and the index is not contained: This will be an implied-zero column for this Matrix type. </para>
+		/// <para> If this Matrix is not column-major and the index is not contained: This will be an implied-zero row for this Matrix type. </para>
+		/// </summary>
+		/// <returns>EmuMath Vector referencing the specified major element within the passed matrix_, or an implied-zero non-major element if it is not contained.</returns>
+		template<std::size_t MajorIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, this_type&>::type GetMajorTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_major_theoretical<MajorIndex_>(*this);
+		}
+
+		template<std::size_t MajorIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, const this_type&>::type GetMajorTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_major_theoretical<MajorIndex_>(*this);
+		}
+
+		/// <summary>
 		/// <para> Accesses the major eement at the provided MajorIndex_ within this Matrix. </para>
 		/// <para> If this Matrix is column-major: This will be an EmuMath Vector of references to respective elements in the row at the specified MajorIndex_. </para>
 		/// <para> If this Matrix is not column-major: This will be an EmuMath Vector of references to respective elements in the column at the specified MajorIndex_. </para>
@@ -684,6 +775,29 @@ namespace EmuMath
 					"Attempted to access a non-major element within an EmuMath Matrix, but the provided NonMajorIndex_ is invalid. The inclusive valid non-major index range is 0:(num_non_major_elements - 1)."
 				);
 			}
+		}
+
+		/// <summary>
+		/// <para> Accesses the theoretical non-major element at the provided NonMajorIndex_ within this Matrix. </para>
+		/// <para> If this Matrix is column-major and the index is contained: This will be a reference to the row at the specified MajorIndex_. </para>
+		/// <para> If this Matrix is not column-major and the index is contained: This will be a reference to the column at the specified MajorIndex_. </para>
+		/// <para> If this Matrix is column-major and the index is not contained: This will be an implied-zero row for this Matrix type. </para>
+		/// <para> If this Matrix is not column-major and the index is not contained: This will be an implied-zero column for this Matrix type. </para>
+		/// </summary>
+		/// <returns>
+		///		EmuMath Vector of references to elements within the specified non-major element within this Matrix, 
+		///		or an implied-zero non-major element if it is not contained.
+		/// </returns>
+		template<std::size_t NonMajorIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, this_type&>::type GetNonMajorTheoretical()
+		{
+			return EmuMath::Helpers::matrix_get_non_major_theoretical<NonMajorIndex_>(*this);
+		}
+
+		template<std::size_t NonMajorIndex_>
+		[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, const this_type&>::type GetNonMajorTheoretical() const
+		{
+			return EmuMath::Helpers::matrix_get_non_major_theoretical<NonMajorIndex_>(*this);
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix.info.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix.info.h
@@ -40,6 +40,10 @@ namespace EmuMath::TMP
 		using row_get_ref_type = std::conditional_t<is_row_major, major_vector_type&, EmuMath::Vector<num_columns, value_type&>>;
 		using column_get_const_ref_type = std::conditional_t<is_column_major, const major_vector_type&, const EmuMath::Vector<num_rows, const value_type&>>;
 		using row_get_const_ref_type = std::conditional_t<is_row_major, const major_vector_type&, const EmuMath::Vector<num_columns, const value_type&>>;
+		using major_get_ref_type = major_vector_type&;
+		using major_get_const_ref_type = const major_vector_type&;
+		using non_major_get_ref_type = std::conditional_t<is_column_major, row_get_ref_type, column_get_ref_type>;
+		using non_major_get_const_ref_type = std::conditional_t<is_column_major, row_get_const_ref_type, column_get_const_ref_type>;
 	};
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix.info.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix.info.h
@@ -44,6 +44,9 @@ namespace EmuMath::TMP
 		using major_get_const_ref_type = const major_vector_type&;
 		using non_major_get_ref_type = std::conditional_t<is_column_major, row_get_ref_type, column_get_ref_type>;
 		using non_major_get_const_ref_type = std::conditional_t<is_column_major, row_get_const_ref_type, column_get_const_ref_type>;
+
+		// Misc info
+		static constexpr bool is_contiguous = sizeof(matrix_vector_type) == (sizeof(stored_type) * size);
 	};
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_MATRIX_TMP_H_INC_ 1
 
 #include "../../../../EmuCore/TMPHelpers/TypeConvertors.h"
+#include "../../../Vector.h"
 #include <type_traits>
 
 namespace EmuMath
@@ -489,6 +490,52 @@ namespace EmuMath::TMP
 		static constexpr bool is_theoretical = _type_finder::is_theoretical;
 		using type = typename _type_finder::type;
 	};
+
+	template<class Matrix_>
+	struct matrix_largest_axis
+	{
+	private:
+		template<class In_, bool = EmuMath::TMP::is_emu_matrix_v<In_>>
+		struct _value_finder
+		{
+			static constexpr std::size_t value = 0;
+		};
+
+		template<class In_>
+		struct _value_finder<In_, true>
+		{
+			using _in_uq = EmuCore::TMP::remove_ref_cv_t<In_>;
+			static constexpr std::size_t value = EmuCore::TMP::greatest_constant_v<std::size_t, _in_uq::num_columns, _in_uq::num_rows>;
+		};
+
+	public:
+		static constexpr std::size_t value = _value_finder<Matrix_>::value;
+	};
+	template<class Matrix_>
+	static constexpr std::size_t matrix_largest_axis_v = matrix_largest_axis<Matrix_>::value;
+
+	template<class Matrix_>
+	struct matrix_smallest_axis
+	{
+	private:
+		template<class In_, bool = EmuMath::TMP::is_emu_matrix_v<In_>>
+		struct _value_finder
+		{
+			static constexpr std::size_t value = 0;
+		};
+
+		template<class In_>
+		struct _value_finder<In_, true>
+		{
+			using _in_uq = EmuCore::TMP::remove_ref_cv_t<In_>;
+			static constexpr std::size_t value = EmuCore::TMP::smallest_constant_v<std::size_t, _in_uq::num_columns, _in_uq::num_rows>;
+		};
+
+	public:
+		static constexpr std::size_t value = _value_finder<Matrix_>::value;
+	};
+	template<class Matrix_>
+	static constexpr std::size_t matrix_smallest_axis_v = matrix_smallest_axis<Matrix_>::value;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_copy.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_copy.h
@@ -226,7 +226,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 			if constexpr (move_allowed_)
 			{
 				// Move allowed, fallback to copy
-				using move_result = decltype(std::move(_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))));
+				using move_result = decltype(std::move(_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(std::declval<InMatrix_>()))));
 				if constexpr (std::is_constructible_v<out_stored_type, move_result>)
 				{
 					get_return_type intermediate_ = _matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_));

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_copy.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_copy.h
@@ -1,0 +1,362 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_COPY_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_COPY_H_INC_ 1
+
+#include "_matrix_tmp.h"
+#include "_matrix_underlying_get.h"
+
+namespace EmuMath::Helpers::_matrix_underlying
+{
+	template<class OutMatrix_, class InMatrix_, bool DoAssertions_>
+	struct _matrix_compatible_contained_ref_check
+	{
+	private:
+		[[nodiscard]] static constexpr inline bool _get()
+		{
+			using out_uq = EmuCore::TMP::remove_ref_cv_t<OutMatrix_>;
+			using in_uq = EmuCore::TMP::remove_ref_cv_t<InMatrix_>;
+			if constexpr (out_uq::contains_ref)
+			{
+				if constexpr (std::is_lvalue_reference_v<InMatrix_>)
+				{
+					// Lvalue-ref, so we assume we're not working with temp input
+					if constexpr (out_uq::contains_non_const_ref)
+					{
+						// Check for const-compatibility
+						if constexpr (!std::is_const_v<InMatrix_>)
+						{
+							if constexpr (!std::is_const_v<typename in_uq::value_type>)
+							{
+								return true;
+							}
+							else
+							{
+								static_assert(!DoAssertions_, "Invalid ref-compatibility between two EmuMath Matrices: The output Matrix contains non-const references, but the input Matrix (lvalue reference) has a const value_type.");
+								return false;
+							}
+						}
+						else
+						{
+							static_assert(!DoAssertions_, "Invalid ref-compatibility between two EmuMath Matrices: The output Matrix contains non-const references, but the input Matrix (lvalue reference) is const-qualified.");
+							return false;
+						}
+					}
+					else
+					{
+						// No const-safety checks needed
+						return true;
+					}
+				}
+				else if constexpr (in_uq::contains_ref)
+				{
+					// Rvalue-ref or temp value, so we assume we're working with temp input
+					// --- Temp input matrix will be invalid due to dangling references unless it contains references itself, thus we have this else-if branch
+					if constexpr (out_uq::contains_non_const_ref)
+					{
+						if constexpr(std::is_const_v<in_uq>)
+						{
+							if constexpr (in_uq::contains_non_const_ref)
+							{
+								return true;
+							}
+							else
+							{
+								static_assert(!DoAssertions_, "Invalid ref-compatibility between two EmuMath Matrices: The output Matrix contains non-const references, but the input Matrix (value or rvalue-reference) contains const references.");
+								return false;
+							}
+						}
+						else
+						{
+							static_assert(!DoAssertions_, "Invalid ref-compatibility between two EmuMath Matrices: The output Matrix contains non-const references, but the input Matrix (value or rvalue-reference) is const-qualified.");
+							return false;
+						}
+					}
+					else
+					{
+						// No const-safety checks needed
+						return true;
+					}
+				}
+				else
+				{
+					static_assert(!DoAssertions_, "Invalid ref compatibility between two EmuMath Matrices: The output Matrix contains references, but the input Matrix is a value or rvalue reference which suggests that it is temporary, and does not contain references. This is deemed as incompatible to prevent dangling references.");
+					return false;
+				}
+			}
+			else
+			{
+				// No need for compatible references since we're outputting values
+				return true;
+			}
+		}
+
+	public:
+		static constexpr bool value = _get();
+	};
+
+	template<class OutMatrix_, class InMatrix_, bool DoAssertions_, std::size_t ColumnIndex_, std::size_t RowIndex_>
+	[[nodiscard]] constexpr inline bool _matrix_create_from_matrix_index_is_valid()
+	{
+		using in_declval = decltype(std::declval<InMatrix_>());
+		using get_return_type = decltype
+		(
+			_matrix_get_theoretical<ColumnIndex_, RowIndex_>
+			(
+				EmuCore::TMP::lval_ref_cast<in_declval>(std::declval<InMatrix_>())
+			)
+		);
+		using out_stored_type = typename OutMatrix_::stored_type;
+		if constexpr (std::is_lvalue_reference_v<InMatrix_>)
+		{
+			// Copy only
+			if constexpr (std::is_constructible_v<out_stored_type, get_return_type> || EmuCore::TMP::is_static_castable_v<get_return_type, out_stored_type>)
+			{
+				return true;
+			}
+			else
+			{
+				static_assert(!DoAssertions_, "Attempted to copy an item from an index of an EmuMath Matrix to the stored_type of another EmuMath Matrix, but the desired output type could not be constructed or static_cast to from the result of getting said index from the Matrix.");
+				return false;
+			}
+		}
+		else
+		{
+			// Move-allowed, fallback to copy
+			if constexpr (_matrix_index_is_contained<ColumnIndex_, RowIndex_, InMatrix_>())
+			{
+				// Move-or-copy
+				if constexpr (_matrix_compatible_contained_ref_check<OutMatrix_, InMatrix_, DoAssertions_>::value)
+				{
+					using move_result = decltype
+					(
+						std::move
+						(
+							_matrix_get_theoretical<ColumnIndex_, RowIndex_>
+							(
+								EmuCore::TMP::lval_ref_cast<in_declval>(std::declval<InMatrix_>())
+							)
+						)
+					);
+					constexpr bool may_move_ = std::is_constructible_v<out_stored_type, move_result> || EmuCore::TMP::is_static_castable_v<move_result, out_stored_type>;
+					constexpr bool may_copy_ = std::is_constructible_v<out_stored_type, get_return_type> || EmuCore::TMP::is_static_castable_v<get_return_type, out_stored_type>;
+
+					// Do not allow moves for reference-containing outputs
+					if constexpr ((may_move_ && !OutMatrix_::contains_ref) || may_copy_)
+					{
+						return true;
+					}
+					else
+					{
+						static_assert(!DoAssertions_, "Attempted to copy-or-move an item from an index of an EmuMath Matrix to the stored_type of another EmuMath Matrix, but the stored_type of the output Matrix cannot be constructed from a std::move or direct copy of the result of getting at least one of the provided indices.");
+						return false;
+					}
+				}
+				else
+				{
+					static_assert(!DoAssertions_, "Attempted to copy-or-move an item from an index of an EmuMath Matrix to the stored_type of another EmuMath Matrix, but the desired output Matrix has a reference incompatibility with the input Matrix.");
+					return false;
+				}
+			}
+			else
+			{
+				// Theoretical, therefore return is value type, so no manual std::move and no reference output
+				if constexpr (!OutMatrix_::contains_ref)
+				{
+					if constexpr (std::is_constructible_v<out_stored_type, get_return_type> || EmuCore::TMP::is_static_castable_v<get_return_type, out_stored_type>)
+					{
+						return true;
+					}
+					else
+					{
+						static_assert(!DoAssertions_, "Attempted to copy an item from an index of an EmuMath Matrix to the stored_type of another EmuMath Matrix, but at least one accessed index is non-contained and the output Matrix's stored_type cannot be constructed or static_cast to from the result of getting a non-contained index of the input Matrix.");
+						return false;
+					}
+				}
+				else
+				{
+					static_assert(!DoAssertions_, "Attempted to copy an item from an index of an EmuMath Matrix to the stored_type of a reference-containing EmuMath Matrix, but at least one accessed index is not-contained within the input Matrix, and would result in a dangling reference.");
+					return false;
+				}
+			}
+		}
+	}
+
+	template<typename...Args_>
+	[[nodiscard]] constexpr inline bool _halp_me(Args_...args_)
+	{
+		return (... && args_);
+	}
+
+	template<class OutMatrix_, class InMatrix_, bool DoAssertions_, std::size_t...ColumnIndices_, std::size_t...RowIndices_>
+	[[nodiscard]] constexpr inline bool _matrix_create_from_matrix_is_valid
+	(
+		std::index_sequence<ColumnIndices_...> column_indices_,
+		std::index_sequence<RowIndices_...> row_indices_
+	)
+	{
+		constexpr bool is_valid_ = EmuCore::TMP::variadic_and_v
+		<
+			_matrix_create_from_matrix_index_is_valid<OutMatrix_, InMatrix_, DoAssertions_, ColumnIndices_, RowIndices_>()...
+		>;
+		if constexpr (is_valid_)
+		{
+			return true;
+		}
+		else
+		{
+			static_assert(!DoAssertions_, "Matrix validity check for creation from another Matrix type has failed for at least one of the provided indices.");
+			return false;
+		}
+	}
+
+	template<class OutMatrix_, class InMatrix_, std::size_t ColumnIndex_, std::size_t RowIndex_>
+	[[nodiscard]] constexpr inline typename OutMatrix_::stored_type _matrix_create_out_from_index(InMatrix_&& in_matrix_)
+	{
+		using get_return_type = decltype(_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_)));
+		using out_stored_type = typename OutMatrix_::stored_type;
+		if constexpr (_matrix_create_from_matrix_index_is_valid<OutMatrix_, InMatrix_, true, ColumnIndex_, RowIndex_>())
+		{
+			constexpr bool move_allowed_ = EmuCore::TMP::variadic_and_v
+			<
+				_matrix_index_is_contained<ColumnIndex_, RowIndex_, InMatrix_>(),
+				!OutMatrix_::contains_ref,
+				!std::is_lvalue_reference_v<InMatrix_>,
+				_matrix_compatible_contained_ref_check<OutMatrix_, InMatrix_, false>::value
+			>;
+
+			if constexpr (move_allowed_)
+			{
+				// Move allowed, fallback to copy
+				using move_result = decltype(std::move(_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))));
+				if constexpr (std::is_constructible_v<out_stored_type, move_result>)
+				{
+					get_return_type intermediate_ = _matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_));
+					return out_stored_type(std::move(intermediate_));
+				}
+				else if constexpr (EmuCore::TMP::is_static_castable_v<move_result, out_stored_type>)
+				{
+					get_return_type intermediate_ = _matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_));
+					return static_cast<out_stored_type>(std::move(intermediate_));
+				}
+				else if constexpr (std::is_constructible_v<out_stored_type, get_return_type>)
+				{
+					return out_stored_type
+					(
+						_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))
+					);
+				}
+				else if constexpr (EmuCore::TMP::is_static_castable_v<get_return_type, out_stored_type>)
+				{
+					return static_cast<out_stored_type>
+					(
+						_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))
+					);
+				}
+				else
+				{
+					static_assert
+					(
+						EmuCore::TMP::get_false<OutMatrix_>(),
+						"Attempted to copy-or-move an index from an EmuMath Matrix into a new EmuMath Matrix, but neither the type resulting from moving a get result nor the get result itself could be used to create the required output type."
+					);
+				}
+			}
+			else
+			{
+				// Copy only
+				if constexpr (std::is_constructible_v<out_stored_type, get_return_type>)
+				{
+					return out_stored_type
+					(
+						_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))
+					);
+				}
+				else if constexpr (EmuCore::TMP::is_static_castable_v<get_return_type, out_stored_type>)
+				{
+					return static_cast<out_stored_type>
+					(
+						_matrix_get_theoretical<ColumnIndex_, RowIndex_>(EmuCore::TMP::lval_ref_cast<InMatrix_>(in_matrix_))
+					);
+				}
+				else
+				{
+					static_assert
+					(
+						EmuCore::TMP::get_false<OutMatrix_>(),
+						"Attempted to copy an index from an EmuMath Matrix into a new EmuMath Matrix, but the type resulting from a get of an index could be used to create the required output type."
+					);
+				}
+			}
+		}
+		else
+		{
+			static_assert
+			(
+				EmuCore::TMP::get_false<OutMatrix_>(),
+				"Attempted to copy an index from an EmuMath Matrix into a new EmuMath Matrix, but the operation could not complete successfully for at least 1 element."
+			);
+		}
+	}
+
+	template<class OutMatrix_, class InMatrix_, std::size_t...FullColumnIndices_, std::size_t...FullRowIndices_>
+	[[nodiscard]] constexpr inline OutMatrix_ _matrix_copy_execution
+	(
+		InMatrix_&& in_matrix_,
+		std::index_sequence<FullColumnIndices_...> full_column_indices_,
+		std::index_sequence<FullRowIndices_...> full_row_indices_
+	)
+	{
+		// Disable Visual Studio warning about using moved-from object, as we aren't accessing anything after it is moved
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return OutMatrix_
+		(
+			_matrix_create_out_from_index<OutMatrix_, InMatrix_, FullColumnIndices_, FullRowIndices_>
+			(
+				std::forward<InMatrix_>(in_matrix_)
+			)...
+		);
+#pragma warning(pop)
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_,
+		std::size_t OutNumRows_,
+		typename OutT_,
+		bool OutColumnMajor_,
+		class InMatrix_,
+		typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<InMatrix_>>
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> _matrix_copy(InMatrix_&& in_matrix_)
+	{
+		using out_matrix = EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>;
+		if constexpr (out_matrix::size != 0)
+		{
+			using index_sequences = EmuMath::TMP::make_full_matrix_index_sequences<out_matrix>;
+
+			return _matrix_copy_execution<out_matrix>
+			(
+				std::forward<InMatrix_>(in_matrix_),
+				typename index_sequences::column_index_sequence(),
+				typename index_sequences::row_index_sequence()
+			);
+		}
+		else
+		{
+			if constexpr (std::is_default_constructible_v<out_matrix>)
+			{
+				return out_matrix();
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<out_matrix>(),
+					"Attempted to copy an EmuMath Matrix to an empty EmuMath Matrix. This behaviour is allowed, and will simply result in default-construction of the empty Matrix, however the provided output Matrix type cannot be default-constructed."
+				);
+			}
+		}
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
@@ -1,0 +1,123 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_GET_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_GET_H_INC_ 1
+
+#include "_matrix_tmp.h"
+
+namespace EmuMath::Helpers::_matrix_underlying
+{
+	// FLATTENED GETS
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template at<FlattenedIndex_>();
+	}
+
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline const typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template at<FlattenedIndex_>();
+	}
+
+	// COLUMN-ROW GETS
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template at<ColumnIndex_, RowIndex_>();
+	}
+
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline const typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template at<ColumnIndex_, RowIndex_>();
+	}
+
+	// COLUMN GETS
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::column_get_ref_type _matrix_get_column
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetColumn<ColumnIndex_>();
+	}
+
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::column_get_const_ref_type _matrix_get_column
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetColumn<ColumnIndex_>();
+	}
+
+	// ROW GETS
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::row_get_ref_type _matrix_get_row
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetRow<RowIndex_>();
+	}
+
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::row_get_const_ref_type _matrix_get_row
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetRow<RowIndex_>();
+	}
+
+	// MAJOR GETS
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::major_get_ref_type _matrix_get_major
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetMajor<MajorIndex_>();
+	}
+
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::major_get_const_ref_type _matrix_get_major
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetMajor<MajorIndex_>();
+	}
+
+	// NON-MAJOR GETS
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::non_major_get_ref_type _matrix_get_non_major
+	(
+		EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetNonMajor<NonMajorIndex_>();
+	}
+
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::non_major_get_const_ref_type _matrix_get_non_major
+	(
+		const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_
+	)
+	{
+		return matrix_.template GetNonMajor<NonMajorIndex_>();
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
@@ -5,6 +5,34 @@
 
 namespace EmuMath::Helpers::_matrix_underlying
 {
+	// NON-CONTAINED GET
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename Matrix_::value_type_uq _matrix_get_non_contained()
+	{
+		if constexpr (std::is_default_constructible_v<typename Matrix_::value_type_uq>)
+		{
+			return typename Matrix_::value_type_uq();
+		}
+		else if constexpr (EmuCore::TMP::is_valid_make_constant_call<typename Matrix_::value_type_uq, 0, float>())
+		{
+			return EmuCore::TMP::make_constant<typename Matrix_::value_type_uq, 0, float>();
+		}
+		else
+		{
+			static_assert
+			(
+				EmuCore::TMP::get_false<Matrix_>(),
+				"Attempted to create a non-contained element of an EmuMath Matrix, but the provided Matrix_ type cannot have its unqualified value type default-constructed or constructed with a constant of either 0 or 0.0f."
+			);
+		}
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq _matrix_get_non_contained()
+	{
+		return _matrix_get_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
 	// FLATTENED GETS
 	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
 	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
@@ -24,6 +52,37 @@ namespace EmuMath::Helpers::_matrix_underlying
 		return matrix_.template at<FlattenedIndex_>();
 	}
 
+	// FLATTENED THEORETICAL GETS
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_flattened_matrix_index<FlattenedIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template at<FlattenedIndex_>();
+		}
+	}
+
+	template<std::size_t FlattenedIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_flattened_theoretical_get_result<FlattenedIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_flattened_matrix_index<FlattenedIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template at<FlattenedIndex_>();
+		}
+	}
+
 	// COLUMN-ROW GETS
 	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
 	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type& _matrix_get
@@ -41,6 +100,37 @@ namespace EmuMath::Helpers::_matrix_underlying
 	)
 	{
 		return matrix_.template at<ColumnIndex_, RowIndex_>();
+	}
+
+	// COLUMN-ROW THEORETICAL GETS
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_index<ColumnIndex_, RowIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template at<ColumnIndex_, RowIndex_>();
+		}
+	}
+
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_theoretical_get_result<ColumnIndex_, RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_index<ColumnIndex_, RowIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template at<ColumnIndex_, RowIndex_>();
+		}
 	}
 
 	// COLUMN GETS

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_get.h
@@ -7,7 +7,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 {
 	// NON-CONTAINED GET
 	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
-	[[nodiscard]] constexpr inline typename Matrix_::value_type_uq _matrix_get_non_contained()
+	[[nodiscard]] constexpr inline typename EmuCore::TMP::remove_ref_cv_t<Matrix_>::value_type_uq _matrix_get_non_contained()
 	{
 		if constexpr (std::is_default_constructible_v<typename Matrix_::value_type_uq>)
 		{
@@ -31,6 +31,118 @@ namespace EmuMath::Helpers::_matrix_underlying
 	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::value_type_uq _matrix_get_non_contained()
 	{
 		return _matrix_get_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	// NON-CONTAINED COLUMN GET
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_column<Matrix_>::type _matrix_get_column_non_contained()
+	{
+		using out_type = typename EmuMath::TMP::matrix_non_contained_column<Matrix_>::type;
+		if constexpr (std::is_default_constructible_v<out_type>)
+		{
+			return out_type();
+		}
+		else if constexpr (EmuCore::TMP::is_valid_make_constant_call<out_type, 0, float>())
+		{
+			return EmuCore::TMP::make_constant<out_type, 0, float>();
+		}
+		else
+		{
+			static_assert
+			(
+				EmuCore::TMP::get_false<Matrix_>(),
+				"Attempted to create a non-contained column of an EmuMath Matrix, but the determined output type cannot be default-constructed or constructed with an argument of 0 or 0.0f."
+			);
+		}
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_column<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>::type
+	_matrix_get_column_non_contained()
+	{
+		return _matrix_get_column_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	// NON-CONTAINED ROW GET
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_row<Matrix_>::type _matrix_get_row_non_contained()
+	{
+		using out_type = typename EmuMath::TMP::matrix_non_contained_row<Matrix_>::type;
+		if constexpr (std::is_default_constructible_v<out_type>)
+		{
+			return out_type();
+		}
+		else if constexpr (EmuCore::TMP::is_valid_make_constant_call<out_type, 0, float>())
+		{
+			return EmuCore::TMP::make_constant<out_type, 0, float>();
+		}
+		else
+		{
+			static_assert
+			(
+				EmuCore::TMP::get_false<Matrix_>(),
+				"Attempted to create a non-contained row of an EmuMath Matrix, but the determined output type cannot be default-constructed or constructed with an argument of 0 or 0.0f."
+			);
+		}
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_contained_row<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>::type
+	_matrix_get_row_non_contained()
+	{
+		return _matrix_get_row_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	// NON-CONTAINED MAJOR GET
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename std::conditional
+	<
+		EmuCore::TMP::remove_ref_cv_t<Matrix_>::is_column_major,
+		decltype(_matrix_get_column_non_contained<Matrix_>()),
+		decltype(_matrix_get_row_non_contained<Matrix_>())
+	>::type _matrix_get_major_non_contained()
+	{
+		if constexpr (EmuCore::TMP::remove_ref_cv_t<Matrix_>::is_column_major)
+		{
+			return _matrix_get_column_non_contained<Matrix_>();
+		}
+		else
+		{
+			return _matrix_get_row_non_contained<Matrix_>();
+		}
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline decltype(_matrix_get_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>())
+	_matrix_get_major_non_contained()
+	{
+		return _matrix_get_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
+	}
+
+	// NON-CONTAINED NON-MAJOR GET
+	template<class Matrix_, typename = std::enable_if_t<EmuMath::TMP::is_emu_matrix_v<Matrix_>>>
+	[[nodiscard]] constexpr inline typename std::conditional
+	<
+		EmuCore::TMP::remove_ref_cv_t<Matrix_>::is_column_major,
+		decltype(_matrix_get_row_non_contained<Matrix_>()),
+		decltype(_matrix_get_column_non_contained<Matrix_>())
+	>::type _matrix_get_non_major_non_contained()
+	{
+		if constexpr (EmuCore::TMP::remove_ref_cv_t<Matrix_>::is_column_major)
+		{
+			return _matrix_get_row_non_contained<Matrix_>();
+		}
+		else
+		{
+			return _matrix_get_column_non_contained<Matrix_>();
+		}
+	}
+
+	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline decltype(_matrix_get_non_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>())
+	_matrix_get_non_major_non_contained()
+	{
+		return _matrix_get_non_major_non_contained<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>();
 	}
 
 	// FLATTENED GETS
@@ -152,6 +264,37 @@ namespace EmuMath::Helpers::_matrix_underlying
 		return matrix_.template GetColumn<ColumnIndex_>();
 	}
 
+	// COLUMN THEORETICAL GETS
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_column_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_column_index<ColumnIndex_, matrix_type>::value)
+		{
+			return _matrix_get_column_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetColumn<ColumnIndex_>();
+		}
+	}
+
+	template<std::size_t ColumnIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_column_theoretical_get_result<ColumnIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_column_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_column_index<ColumnIndex_, matrix_type>::value)
+		{
+			return _matrix_get_column_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetColumn<ColumnIndex_>();
+		}
+	}
+
 	// ROW GETS
 	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
 	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::row_get_ref_type _matrix_get_row
@@ -169,6 +312,37 @@ namespace EmuMath::Helpers::_matrix_underlying
 	)
 	{
 		return matrix_.template GetRow<RowIndex_>();
+	}
+
+	// ROW THEORETICAL GETS
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_row_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_row_index<RowIndex_, matrix_type>::value)
+		{
+			return _matrix_get_row_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetRow<RowIndex_>();
+		}
+	}
+
+	template<std::size_t RowIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_row_theoretical_get_result<RowIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_row_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_row_index<RowIndex_, matrix_type>::value)
+		{
+			return _matrix_get_row_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetRow<RowIndex_>();
+		}
 	}
 
 	// MAJOR GETS
@@ -190,6 +364,36 @@ namespace EmuMath::Helpers::_matrix_underlying
 		return matrix_.template GetMajor<MajorIndex_>();
 	}
 
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_major_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_major_index<MajorIndex_, matrix_type>::value)
+		{
+			return _matrix_get_major_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetMajor<MajorIndex_>();
+		}
+	}
+
+	template<std::size_t MajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_major_theoretical_get_result<MajorIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_major_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_major_index<MajorIndex_, matrix_type>::value)
+		{
+			return _matrix_get_major_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetMajor<MajorIndex_>();
+		}
+	}
+
 	// NON-MAJOR GETS
 	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
 	[[nodiscard]] constexpr inline typename EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>::non_major_get_ref_type _matrix_get_non_major
@@ -207,6 +411,37 @@ namespace EmuMath::Helpers::_matrix_underlying
 	)
 	{
 		return matrix_.template GetNonMajor<NonMajorIndex_>();
+	}
+
+	// NON-MAJOR THEORETICAL GETS
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_non_major_theoretical(EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_non_major_index<NonMajorIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_major_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetNonMajor<NonMajorIndex_>();
+		}
+	}
+
+	template<std::size_t NonMajorIndex_, typename T_, std::size_t NumColumns_, std::size_t NumRows_, bool ColumnMajor_>
+	[[nodiscard]] constexpr inline typename EmuMath::TMP::matrix_non_major_theoretical_get_result<NonMajorIndex_, const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>&>::type
+	_matrix_get_non_major_theoretical(const EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>& matrix_)
+	{
+		using matrix_type = EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>;
+		if constexpr (EmuMath::TMP::is_theoretical_matrix_non_major_index<NonMajorIndex_, matrix_type>::value)
+		{
+			return _matrix_get_non_major_non_contained<matrix_type>();
+		}
+		else
+		{
+			return matrix_.template GetNonMajor<NonMajorIndex_>();
+		}
 	}
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_set_underlying.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_set_underlying.h
@@ -114,8 +114,22 @@ namespace EmuMath::Helpers::_vector_underlying
 			using rhs_vector_type = EmuCore::TMP::remove_ref_cv_t<VectorArg_>;
 			if constexpr (Index_ < rhs_vector_type::size)
 			{
-				_vector_set_scalar<Index_>(out_vector_, std::move(_vector_get<Index_>(in_vector_arg_)));
-				_vector_set_vector_move<Index_ + 1, EndIndex_>(out_vector_, std::move(in_vector_arg_));
+				using lhs_value_type = typename lhs_vector_type::value_type;
+				using rhs_value_type = typename rhs_vector_type::value_type;
+				if constexpr (EmuMath::TMP::is_emu_vector_v<lhs_value_type> && !EmuMath::TMP::is_emu_vector_v<rhs_value_type>)
+				{
+					_vector_set_vector_move<0, EmuCore::TMP::remove_ref_cv_t<lhs_value_type>::size>
+					(
+						_vector_get<Index_>(out_vector_),
+						std::forward<VectorArg_>(in_vector_arg_)
+					);
+					_vector_set_vector_move<Index_ + 1, EndIndex_>(out_vector_, std::forward<VectorArg_>(in_vector_arg_));
+				}
+				else
+				{
+					_vector_set_scalar<Index_>(out_vector_, std::move(_vector_get<Index_>(in_vector_arg_)));
+					_vector_set_vector_move<Index_ + 1, EndIndex_>(out_vector_, std::forward<VectorArg_>(in_vector_arg_));
+				}
 			}
 			else
 			{
@@ -134,8 +148,23 @@ namespace EmuMath::Helpers::_vector_underlying
 			using rhs_vector_type = EmuCore::TMP::remove_ref_cv_t<VectorArg_>;
 			if constexpr (Index_ < rhs_vector_type::size)
 			{
-				_vector_set_scalar<Index_>(out_vector_, _vector_get<Index_>(in_vector_arg_));
-				_vector_set_vector_copy<Index_ + 1, EndIndex_>(out_vector_, in_vector_arg_);
+				using lhs_value_type = typename lhs_vector_type::value_type;
+				using rhs_value_type = typename rhs_vector_type::value_type;
+
+				if constexpr (EmuMath::TMP::is_emu_vector_v<lhs_value_type> && !EmuMath::TMP::is_emu_vector_v<rhs_value_type>)
+				{
+					_vector_set_vector_copy<0, EmuCore::TMP::remove_ref_cv_t<lhs_value_type>::size, VectorArg_>
+					(
+						_vector_get<Index_>(out_vector_),
+						in_vector_arg_
+					);
+					_vector_set_vector_copy<Index_ + 1, EndIndex_, VectorArg_>(out_vector_, in_vector_arg_);
+				}
+				else
+				{
+					_vector_set_scalar<Index_>(out_vector_, _vector_get<Index_>(in_vector_arg_));
+					_vector_set_vector_copy<Index_ + 1, EndIndex_, VectorArg_>(out_vector_, in_vector_arg_);
+				}
 			}
 			else
 			{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -51,6 +51,12 @@ namespace EmuMath
 		using data_storage_type = std::array<stored_type, size>;
 		using index_sequence = std::make_index_sequence<size>;
 
+		/// <summary> Functional approach to retrieve this Vector's size. Returns this type's `size` value. </summary>
+		[[nodiscard]] static constexpr inline std::size_t get_size()
+		{
+			return size;
+		}
+
 		template<class...Args_>
 		[[nodiscard]] static constexpr inline bool valid_template_construction_args()
 		{
@@ -6410,7 +6416,7 @@ namespace EmuMath
 		<
 			typename OutT_,
 			std::size_t Offset_ = 0,
-			typename = std::enable_if_t<EmuMath::Helpers::vector_cast_is_valid<const this_type&, size, OutT_, Offset_>()>
+			typename = std::enable_if_t<EmuMath::Helpers::vector_cast_is_valid<const this_type&, get_size(), OutT_, Offset_>()>
 		>
 		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Cast() const
 		{
@@ -6442,7 +6448,7 @@ namespace EmuMath
 		<
 			typename OutT_,
 			std::size_t Offset_ = 0,
-			typename = std::enable_if_t<EmuMath::Helpers::vector_cast_is_valid<this_type&, size, OutT_, Offset_>()>
+			typename = std::enable_if_t<EmuMath::Helpers::vector_cast_is_valid<this_type&, get_size(), OutT_, Offset_>()>
 		>
 		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Cast()
 		{

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -246,6 +246,10 @@ int main()
 	std::cout << some_mat_3x4f_rm_ << "\n\n";
 
 	constexpr auto some_mat_3x4f_cm_copy_ = EmuMath::Matrix<3, 4, float, true>(some_mat_3x4f_cm_);
+	constexpr auto column_1_ = some_mat_3x4f_cm_copy_.GetColumn<1>();
+	constexpr auto row_2_ = some_mat_3x4f_cm_copy_.GetRow<2>().Cast<float>();
+
+	using row_get = decltype(some_mat_3x4f_cm_.GetRow<2>());
 
 	system("pause");
 	

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -260,6 +260,23 @@ int main()
 
 	using row_get = decltype(some_mat_3x4f_cm_.GetRow<2>());
 
+	EmuMath::Matrix<3, 4, float, false> tester_;
+	constexpr auto zero_ = tester_.get_implied_zero();
+	constexpr auto zero_column_ = tester_.get_implied_zero_column();
+	constexpr auto zero_row_ = tester_.get_implied_zero_row();
+	constexpr auto zero_major_ = tester_.get_implied_zero_major();
+	constexpr auto zero_non_major_ = tester_.get_implied_zero_non_major();
+
+	auto column_theoretical_0_ = tester_.GetColumnTheoretical<0>();
+	auto column_theoretical_1_ = tester_.GetColumnTheoretical<25>();
+	auto& row_theoretical_0_ = tester_.GetRowTheoretical<0>();
+	auto row_theoretical_1_ = tester_.GetRowTheoretical<25>();
+	auto& major_theoretical_0_ = tester_.GetMajorTheoretical<0>();
+	auto major_theoretical_1_ = tester_.GetMajorTheoretical<25>();
+	auto non_major_theoretical_0_ = tester_.GetNonMajorTheoretical<0>();
+	auto non_major_theoretical_1_ = tester_.GetNonMajorTheoretical<25>();
+
+
 	system("pause");
 	
 	// ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -256,10 +256,6 @@ int main()
 	constexpr auto theoretical_test_4_ = some_mat_3x4f_cm_.AtTheoretical<25, 0>();
 	constexpr auto theoretical_test_5_ = some_mat_3x4f_cm_.AtTheoretical<25, 25>();
 
-	using matrix = EmuMath::Matrix<3, 4, float, true>;
-
-	using row_get = decltype(some_mat_3x4f_cm_.GetRow<2>());
-
 	EmuMath::Matrix<3, 4, float, false> tester_;
 	constexpr auto zero_ = tester_.get_implied_zero();
 	constexpr auto zero_column_ = tester_.get_implied_zero_column();
@@ -276,6 +272,46 @@ int main()
 	auto non_major_theoretical_0_ = tester_.GetNonMajorTheoretical<0>();
 	auto non_major_theoretical_1_ = tester_.GetNonMajorTheoretical<25>();
 
+	std::cout << "\n---\n";
+	constexpr auto read_mat_cm_ = EmuMath::Matrix<4, 4, float, true>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	constexpr auto read_mat_rm_ = EmuMath::Matrix<4, 4, float, false>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	std::cout << "Column Major:\n" << read_mat_cm_ << "\n\nRow Major:\n" << read_mat_rm_ << "\n\n";
+
+	std::cout << "\n---\n";
+	constexpr auto mat_from_vecs_cm_ = EmuMath::Matrix<4, 3, float, true>
+	(
+		EmuMath::Vector<3, float>(1, 2, 3),
+		EmuMath::Vector<3, float>(4, 5, 6),
+		EmuMath::Vector<3, float>(7, 8, 9),
+		EmuMath::Vector<3, float>(10, 11, 12)
+	);
+	constexpr auto mat_from_vecs_rm_ = EmuMath::Matrix<4, 3, float, false>
+	(
+		EmuMath::Vector<4, float>(1, 2, 3, 4),
+		EmuMath::Vector<4, float>(5, 6, 7, 8),
+		EmuMath::Vector<4, float>(9, 10, 11, 12)
+	);
+
+	std::cout << "\n---\n";
+	constexpr auto mat_from_vec_move_cm_ = EmuMath::Matrix<4, 3, float, true>
+	(
+		EmuMath::Matrix<4, 3, float, true>::matrix_vector_type
+		(
+			EmuMath::Vector<3, float>(1, 2, 3),
+			EmuMath::Vector<3, float>(4, 5, 6),
+			EmuMath::Vector<3, float>(7, 8, 9),
+			EmuMath::Vector<3, float>(10, 11, 12)
+		)
+	);
+	constexpr auto mat_from_vec_move_rm_ = EmuMath::Matrix<4, 3, float, false>
+	(
+		EmuMath::Matrix<4, 3, float, false>::matrix_vector_type
+		(
+			EmuMath::Vector<4, float>(1, 2, 3, 4),
+			EmuMath::Vector<4, float>(5, 6, 7, 8),
+			EmuMath::Vector<4, float>(9, 10, 11, 12)
+		)
+	);
 
 	system("pause");
 	

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -154,6 +154,31 @@ inline void WriteNoiseTableToPPM
 	}
 }
 
+template<class OutMatrix_, class InMatrix_, class ColumnIndices_, class RowIndices_>
+struct _matrix_index_sequences_test
+{
+};
+
+template<class OutMatrix_, class InMatrix_, std::size_t...ColumnIndices_, std::size_t...RowIndices_>
+struct _matrix_index_sequences_test<OutMatrix_, InMatrix_, std::index_sequence<ColumnIndices_...>, std::index_sequence<RowIndices_...>>
+{
+	static constexpr std::size_t num_columns_ = sizeof...(ColumnIndices_);
+	static constexpr std::size_t num_rows_ = sizeof...(RowIndices_);
+	using column_index_sequence = typename EmuCore::TMP::variadic_splice_integer_sequences
+	<
+		EmuCore::TMP::make_duplicated_index_sequence<ColumnIndices_, num_rows_>...
+	>::type;
+	using row_index_sequence = typename EmuCore::TMP::looped_integer_sequence<std::index_sequence<RowIndices_...>, num_columns_ - 1>::type;
+};
+
+template<typename T_, T_...Indices_>
+void PrintIntSequence(std::integer_sequence<T_, Indices_...>)
+{
+	std::cout << "{ ";
+	((std::cout << Indices_ << ", "), ...);
+	std::cout << " }";
+}
+
 int main()
 {
 	srand(static_cast<unsigned int>(time(0)));
@@ -330,7 +355,35 @@ int main()
 	runtime_mat_4x4f_cm_.MainDiagonal<float&>() *= 10.0f;
 	std::cout << runtime_mat_4x4f_cm_ << "\n\n";
 
+	std::cout << "\n---\n";
+	constexpr auto mat_to_copy_cm_ = EmuMath::Matrix<4, 4, float, true>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	constexpr auto mat_to_copy_rm_ = EmuMath::Matrix<4, 4, float, false>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
 
+	std::cout << "Full CM:\n" << mat_to_copy_cm_ << "\n\nFull RM:\n" << mat_to_copy_rm_ << "\n\n";
+
+	constexpr auto copy_mat_2x4i32_cm_from_cm_ = EmuMath::Helpers::matrix_copy<2, 4, std::int32_t, true>(mat_to_copy_cm_);
+	constexpr auto copy_mat_2x4i32_cm_from_rm_ = EmuMath::Helpers::matrix_copy<2, 4, std::int32_t, true>(mat_to_copy_rm_);
+	std::cout << "CM FROM CM:\n" << copy_mat_2x4i32_cm_from_cm_ << "\n\nCM FROM RM:\n" << copy_mat_2x4i32_cm_from_rm_ << "\n\n";
+
+	constexpr auto copy_mat_2x4i32_rm_from_cm_ = EmuMath::Helpers::matrix_copy<2, 4, std::int32_t, false>(mat_to_copy_cm_);
+	constexpr auto copy_mat_2x4i32_rm_from_rm_ = EmuMath::Helpers::matrix_copy<2, 4, std::int32_t, false>(mat_to_copy_rm_);
+	std::cout << "RM FROM CM:\n" << copy_mat_2x4i32_rm_from_cm_ << "\n\nRM FROM RM:\n" << copy_mat_2x4i32_rm_from_rm_ << "\n\n";
+
+	std::cout << "\n---\n";
+	constexpr auto constructed_copy_ = EmuMath::Matrix<12, 7, long double, true>(copy_mat_2x4i32_cm_from_rm_);
+	std::cout << constructed_copy_ << "\n\n";
+
+	constexpr auto moved_copy_ = EmuMath::Matrix<4, 4, float, true>
+	(
+		EmuMath::Matrix<5, 3, float, false>
+		(
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+		)
+	);
+
+	constexpr bool halp_ = EmuMath::Helpers::matrix_assert_copy_is_valid<4, 4, const float&, true, decltype(moved_copy_)&>();
+	auto mat_to_ref_ = EmuMath::Matrix<4, 4, float, true>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	auto ref_copy_ = EmuMath::Matrix<4, 4, float&, true>(mat_to_ref_);
 
 
 

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -249,6 +249,15 @@ int main()
 	constexpr auto column_1_ = some_mat_3x4f_cm_copy_.GetColumn<1>();
 	constexpr auto row_2_ = some_mat_3x4f_cm_copy_.GetRow<2>().Cast<float>();
 
+	constexpr auto theoretical_test_0_ = some_mat_3x4f_cm_.AtTheoretical<25>();
+	constexpr auto theoretical_test_1_ = some_mat_3x4f_cm_.AtTheoretical<3>();
+	constexpr auto theoretical_test_2_ = some_mat_3x4f_cm_.AtTheoretical<1, 2>();
+	constexpr auto theoretical_test_3_ = some_mat_3x4f_cm_.AtTheoretical<0, 25>();
+	constexpr auto theoretical_test_4_ = some_mat_3x4f_cm_.AtTheoretical<25, 0>();
+	constexpr auto theoretical_test_5_ = some_mat_3x4f_cm_.AtTheoretical<25, 25>();
+
+	using matrix = EmuMath::Matrix<3, 4, float, true>;
+
 	using row_get = decltype(some_mat_3x4f_cm_.GetRow<2>());
 
 	system("pause");

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -313,6 +313,27 @@ int main()
 		)
 	);
 
+	std::cout << "\n---\n";
+	constexpr auto main_diagonal_cm_normal_ = mat_from_vec_move_cm_.MainDiagonal();
+	constexpr auto main_diagonal_rm_normal_ = mat_from_vec_move_rm_.MainDiagonal();
+	constexpr auto main_diagonal_cm_smaller_no_offset_ = mat_from_vec_move_cm_.MainDiagonal<2>();
+	constexpr auto main_diagonal_rm_smaller_no_offset_ = mat_from_vec_move_rm_.MainDiagonal<2>();
+	constexpr auto main_diagonal_cm_smaller_offset_ = mat_from_vec_move_cm_.MainDiagonal<2, 1>();
+	constexpr auto main_diagonal_rm_smaller_offset_ = mat_from_vec_move_rm_.MainDiagonal<2, 1>();
+	constexpr auto main_diagonal_cm_larger_no_offset_ = mat_from_vec_move_cm_.MainDiagonal<5>();
+	constexpr auto main_diagonal_rm_larger_no_offset_ = mat_from_vec_move_rm_.MainDiagonal<5>();
+	constexpr auto main_diagonal_cm_larger_offset_ = mat_from_vec_move_cm_.MainDiagonal<5, 25>();
+	constexpr auto main_diagonal_rm_larger_offset_ = mat_from_vec_move_rm_.MainDiagonal<5, 25>();
+
+	EmuMath::Matrix<4, 4, float, true> runtime_mat_4x4f_cm_(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	std::cout << runtime_mat_4x4f_cm_ << "\n\n";
+	runtime_mat_4x4f_cm_.MainDiagonal<float&>() *= 10.0f;
+	std::cout << runtime_mat_4x4f_cm_ << "\n\n";
+
+
+
+
+
 	system("pause");
 	
 	// ##### SCALAR vs SIMD NOISE #####


### PR DESCRIPTION
Matrices may now be constructed via:
- Default construction `()`
- Const and non-const copy construction `(same_type&)` and `(const same_type&`)
- Move construction `(same_type&&)`
- Conversion of another `EmuMath::Matrix` via either copy-conversion or move-conversion (with fallback to copy where moves are not applicable). `(other_matrix_type&)`, `(const other_matrix_type&)`, `(other_matrix_type&&)`, and `(const other_matrix_type&&)`
- Variadic arguments which have been designed to take further interpretations, but currently are interpreted in one of two ways, taking priority from top to bottom where more than one is valid:
   1. A selection of `EmuMath::Vector` arguments representing arguments for each major Vector within the Matrix
      - The number of arguments in the constructor must be equal to `num_major_elements` - which itself is equal to `num_columns` in column-major Matrices, or `num_rows` in row-major Matrices.
      - All arguments must be an instance of `EmuMath::Vector`
      - Passed Vectors do not require a matching size to the size of a major element, but their type (and implied-zero type if it is needed) must be valid for constructing or `static_cast`ing to the Matrix's `stored_type`.
   2. A selection of arguments which may be used to construct the Matrix's `stored_type` for each element within the Matrix.
      - The number of arguments in the constructor must be equal to `size` - which itself is equal to `num_columns * num_rows`.
      - Arguments may be any type, as long as it meets validity requirements.
      - To be valid, a type must be valid as a single argument when forwarded to the constructor of the Matrix's `stored_type`.

Assignment will come in the next merge.