### PR TITLE
STL Iterators for EmuMath::Vector

### DIFF
--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -204,6 +204,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_bitwise_assign.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_cast.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_cmp.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_iterator.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_misc_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_basic_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_copy.h" />
@@ -220,6 +221,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_copy_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_get_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_info.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_iterator_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_misc_arithmetic_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_mutation_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_special_operations_underlying.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -488,5 +488,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_mutate.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_vector_iterator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_iterator_underlying.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_common_vector_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_common_vector_helpers.h
@@ -6,6 +6,7 @@
 #include "../_underlying_helpers/_vector_copy_underlying.h"
 #include "../_underlying_helpers/_vector_get_underlying.h"
 #include "../_underlying_helpers/_vector_info.h"
+#include "../_underlying_helpers/_vector_iterator_underlying.h"
 #include "../_underlying_helpers/_vector_misc_arithmetic_underlying.h"
 #include "../_underlying_helpers/_vector_mutation_underlying.h"
 #include "../_underlying_helpers/_vector_special_operations_underlying.h"

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_helpers.h
@@ -14,6 +14,7 @@
 #include "_vector_cmp.h"
 #include "_vector_copy.h"
 #include "_vector_get.h"
+#include "_vector_iterator.h"
 #include "_vector_misc_arithmetic.h"
 #include "_vector_mutation.h"
 #include "_vector_rounds.h"

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_iterator.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_iterator.h
@@ -1,0 +1,27 @@
+#ifndef EMU_MATH_VECTOR_ITERATOR_H_INC_
+#define EMU_MATH_VECTOR_ITERATOR_H_INC_
+
+#include "_common_vector_helpers.h"
+
+// CONTAINS:
+// --- vector_iterator
+// --- vector_const_iterator
+// --- vector_reverse_iterator
+// --- vector_const_reverse_iterator
+
+namespace EmuMath
+{
+	template<class Vector_>
+	using vector_iterator = EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, false>;
+
+	template<class Vector_>
+	using vector_const_iterator = EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<const Vector_, false>;
+
+	template<class Vector_>
+	using vector_reverse_iterator = EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, true>;
+
+	template<class Vector_>
+	using vector_const_reverse_iterator = EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<const Vector_, true>;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_copy_underlying.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_copy_underlying.h
@@ -371,7 +371,11 @@ namespace EmuMath::Helpers::_vector_underlying
 	template<std::size_t CopyBegin_, std::size_t CopyEnd_, std::size_t ReadOffset_, bool AllowScalarMove_, class OutVector_, class In_, std::size_t...Indices_>
 	constexpr inline void _vector_copy_assign_execution(std::index_sequence<Indices_...> indices_, OutVector_& out_, In_&& in_)
 	{
+		// We don't allow moves where a problem would occur, so silence false-positive VS warning here
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		(_vector_copy_index_in_range<Indices_, CopyBegin_, CopyEnd_, ReadOffset_, AllowScalarMove_>(out_, std::forward<In_>(in_)), ...);
+#pragma warning(pop)
 	}
 	
 	template<std::size_t CopyBegin_, std::size_t CopyEnd_, std::size_t ReadOffset_, class In_, std::size_t OutSize_, typename OutT_>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_iterator_underlying.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_iterator_underlying.h
@@ -1,0 +1,309 @@
+#ifndef EMU_MATH_VECTOR_ITERATOR_UNDERLYING_H_INC_
+#define EMU_MATH_VECTOR_ITERATOR_UNDERLYING_H_INC_ 1
+
+#include "_vector_tmp.h"
+#include "../../../../EmuCore/TMPHelpers/TypeComparators.h"
+#include <cstddef>
+
+namespace EmuMath::Helpers::_vector_underlying
+{
+	template<class Vector_, bool Reverse_ = false>
+	struct _vector_iterator_underlying
+	{
+	private:
+		static_assert(EmuMath::TMP::is_emu_vector_v<Vector_>, "Attempted to create an EmuMath vector_iterator with a non-EmuMath-Vector argument type.");
+		using _vector_type = EmuCore::TMP::remove_ref_cv_t<Vector_>;
+		friend typename _vector_type;
+
+		static constexpr bool _is_const = std::is_const_v<Vector_>;
+		using _stored_type = typename EmuCore::TMP::conditional_const<_is_const, typename _vector_type::stored_type>::type;
+
+		/// <summary> Constructor that may only be invoked by the Vector that this iterator is for. </summary>
+		/// <param name="val_pointer_">: Pointer to the item that this iterator points to.</param>
+		/// <param name="index_">: Index of the pointed-to element. If this is for end, it should be size. If it is for reverse end, it should be -1.</param>
+		constexpr inline _vector_iterator_underlying(_stored_type* val_pointer_, std::size_t index_) noexcept : _p_item(val_pointer_), _index(index_)
+		{
+		}
+
+	public:
+		using this_type = EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, Reverse_>;
+
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type = typename _vector_type::value_type;
+		using pointer = typename EmuCore::TMP::conditional_const<_is_const, value_type*>::type;
+		using reference = typename EmuCore::TMP::conditional_const<_is_const, value_type&>::type;
+		using difference_type = std::ptrdiff_t;
+
+#pragma region CONSTRUCTORS
+		/// <summary> Default constructor which creates an invalid iterator. </summary>
+		_vector_iterator_underlying() : _p_item(nullptr), _index(std::numeric_limits<difference_type>::lowest())
+		{
+		};
+
+		constexpr inline _vector_iterator_underlying(const this_type& to_copy_) noexcept : _p_item(to_copy_._p_item), _index(to_copy_._index)
+		{
+		}
+
+		constexpr inline _vector_iterator_underlying(this_type&& to_move_) noexcept : _p_item(to_move_._p_item), _index(to_move_._index)
+		{
+		}
+#pragma endregion
+
+#pragma region ACCESS
+		[[nodiscard]] constexpr inline reference operator*()
+		{
+			if constexpr (_vector_type::contains_ref)
+			{
+				return (*_p_item).get();
+			}
+			else
+			{
+				return *_p_item;
+			}
+		}
+
+		[[nodiscard]] constexpr inline const reference operator*() const
+		{
+			return const_cast<this_type*>(this)->operator*();
+		}
+
+		[[nodiscard]] constexpr inline pointer operator->()
+		{
+			if constexpr (_vector_type::contains_ref)
+			{
+				return &(_p_item->get());
+			}
+			else
+			{
+				return _p_item;
+			}
+		}
+
+		[[nodiscard]] constexpr inline const pointer operator->() const
+		{
+			return const_cast<this_type*>(this)->operator->();
+		}
+
+		[[nodiscard]] constexpr inline reference operator[](difference_type offset_)
+		{
+			if constexpr (Reverse_)
+			{
+				return *(_p_item - offset_);
+			}
+			else
+			{
+				return *(_p_item + offset_);
+			}
+		}
+
+		[[nodiscard]] constexpr inline const reference operator[](difference_type offset_) const
+		{
+			return const_cast<this_type*>(this)->operator[](offset_);
+		}
+#pragma endregion
+
+#pragma region COMPARISON
+		[[nodiscard]] constexpr inline bool operator==(const this_type& rhs_) const noexcept
+		{
+			return _p_item == rhs_._p_item;
+		}
+
+		[[nodiscard]] constexpr inline bool operator!=(const this_type& rhs_) const noexcept
+		{
+			return _p_item != rhs_._p_item;
+		}
+
+		[[nodiscard]] constexpr inline bool operator>(const this_type& rhs_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return rhs_._p_item > _p_item;
+			}
+			else
+			{
+				return _p_item > rhs_._p_item;
+			}
+		}
+
+		[[nodiscard]] constexpr inline bool operator<(const this_type& rhs_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return rhs_._p_item < _p_item;
+			}
+			else
+			{
+				return _p_item < rhs_._p_item;
+			}
+		}
+
+		[[nodiscard]] constexpr inline bool operator>=(const this_type& rhs_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return rhs_._p_item >= _p_item;
+			}
+			else
+			{
+				return _p_item >= rhs_._p_item;
+			}
+		}
+
+		[[nodiscard]] constexpr inline bool operator<=(const this_type& rhs_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return rhs_._p_item <= _p_item;
+			}
+			else
+			{
+				return _p_item <= rhs_._p_item;
+			}
+		}
+#pragma endregion
+
+#pragma region ASSIGNMENT
+		constexpr inline this_type& operator=(const this_type& to_copy_) noexcept
+		{
+			_p_item = to_copy_._p_item;
+			_index = to_copy_._index;
+			return *this;
+		}
+
+		constexpr inline this_type& operator=(this_type&& to_move_) noexcept
+		{
+			_p_item = to_move_._p_item;
+			_index = to_move_._index;
+			return *this;
+		}
+#pragma endregion
+
+#pragma region ARITHMETIC
+		constexpr inline this_type& operator++() noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				--_p_item;
+				--_index;
+			}
+			else
+			{
+				++_p_item;
+				++_index;
+			}
+			return *this;
+		}
+
+		constexpr inline this_type operator++(int) noexcept
+		{
+			this_type out_(_p_item);
+			this->operator++();
+			return out_;
+		}
+
+		constexpr inline this_type& operator--() noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				++_p_item;
+				++_index;
+			}
+			else
+			{
+				--_p_item;
+				--_index;
+			}
+			return *this;
+		}
+
+		constexpr inline this_type operator--(int) noexcept
+		{
+			this_type out_(_p_item);
+			this->operator--();
+			return out_;
+		}
+
+		[[nodiscard]] constexpr inline difference_type operator-(const this_type& rhs_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return rhs_._index - _index;
+			}
+			else
+			{
+				return _index - rhs_._index;
+			}
+		}
+
+		[[nodiscard]] constexpr inline this_type operator+(difference_type increment_count_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return this_type(_p_item - increment_count_, _index - increment_count_);
+			}
+			else
+			{
+				return this_type(_p_item + increment_count_, _index + increment_count_);
+			}
+		}
+
+		[[nodiscard]] constexpr inline this_type operator-(difference_type decrement_count_) const noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				return this_type(_p_item + decrement_count_, _index + decrement_count_);
+			}
+			else
+			{
+				return this_type(_p_item - decrement_count_, _index - decrement_count_);
+			}
+		}
+
+		constexpr inline this_type& operator+=(difference_type increment_count_) noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				_p_item -= increment_count_;
+				_index -= increment_count_;
+			}
+			else
+			{
+				_p_item += increment_count_;
+				_index += increment_count_;
+			}
+			return *this;
+		}
+
+		constexpr inline this_type& operator-=(difference_type decrement_count_) noexcept
+		{
+			if constexpr (Reverse_)
+			{
+				_p_item += decrement_count_;
+				_index += decrement_count_;
+			}
+			else
+			{
+				_p_item -= decrement_count_;
+				_index -= decrement_count_;
+			}
+			return *this;
+		}
+#pragma endregion
+
+	private:
+		_stored_type* _p_item;
+		difference_type _index;
+	};
+}
+
+template<class Vector_, bool Reverse_>
+[[nodiscard]] constexpr inline EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, Reverse_> operator+
+(
+	typename EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, Reverse_>::difference_type offset_,
+	const EmuMath::Helpers::_vector_underlying::_vector_iterator_underlying<Vector_, Reverse_>& iterator_
+)
+{
+	return (iterator_ + offset_);
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -25,6 +25,15 @@ namespace EmuMath
 		using alternative_rep = typename vector_info::alternative_vector_rep;
 		friend typename alternative_rep;
 
+		/// <summary> STL-compliant random-access iterator for this Vector type. </summary>
+		using iterator = EmuMath::vector_iterator<this_type>;
+		/// <summary> STL-compliant constant random-access iterator for this Vector type. </summary>
+		using const_iterator = EmuMath::vector_const_iterator<this_type>;
+		/// <summary> STL-compliant reverse random-access iterator for this Vector type. </summary>
+		using reverse_iterator = EmuMath::vector_reverse_iterator<this_type>;
+		/// <summary> STL-compliant constant reverse random-access iterator for this Vector type. </summary>
+		using const_reverse_iterator = EmuMath::vector_const_reverse_iterator<this_type>;
+
 		/// <summary> The number of elements contained within this Vector type. </summary>
 		static constexpr std::size_t size = vector_info::size;
 		/// <summary> True if this Vector contains any kind of reference(s). </summary>
@@ -772,7 +781,7 @@ namespace EmuMath
 #pragma warning(push)
 #pragma warning(disable: 26800)
 				return data_storage_type({ _make_stored_type_from_arg<Indices_, ReadOffset_, allow_move_between_depths_>(std::forward<Arg_>(arg_))... });
-#pragma endregion
+#pragma warning(pop)
 			}
 			else
 			{
@@ -1305,6 +1314,80 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region STL_ACCESS
+	public:
+		[[nodiscard]] constexpr inline const_iterator cbegin() const
+		{
+			return const_iterator(_data.data(), 0);
+		}
+
+		[[nodiscard]] constexpr inline const_iterator cend() const
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type size_as_diff_ = static_cast<diff_type>(size);
+			return const_iterator(_data.data() + size, size_as_diff_);
+		}
+
+		[[nodiscard]] constexpr inline const_reverse_iterator crbegin() const
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type final_index_ = static_cast<diff_type>(size) - 1;
+			return const_reverse_iterator(_data.data() + final_index_, final_index_);
+		}
+
+		[[nodiscard]] constexpr inline const_reverse_iterator crend() const
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type minus_one_ = diff_type(-1);
+			return const_reverse_iterator(_data.data() - 1, minus_one_);
+		}
+
+		[[nodiscard]] constexpr inline iterator begin()
+		{
+			return iterator(_data.data(), 0);
+		}
+
+		[[nodiscard]] constexpr inline const_iterator begin() const
+		{
+			return cbegin();
+		}
+
+		[[nodiscard]] constexpr inline iterator end()
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type size_as_diff_ = static_cast<diff_type>(size);
+			return iterator(_data.data() + size, size_as_diff_);
+		}
+
+		[[nodiscard]] constexpr inline const_iterator end() const
+		{
+			return cend();
+		}
+
+		[[nodiscard]] constexpr inline reverse_iterator rbegin()
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type final_index_ = static_cast<diff_type>(size) - 1;
+			return reverse_iterator(_data.data() + final_index_, final_index_);
+		}
+
+		[[nodiscard]] constexpr inline const_reverse_iterator rbegin() const
+		{
+			return crbegin();
+		}
+
+		[[nodiscard]] constexpr inline reverse_iterator rend()
+		{
+			using diff_type = typename const_reverse_iterator::difference_type;
+			constexpr diff_type minus_one_ = diff_type(-1);
+			return reverse_iterator(_data.data() - 1, minus_one_);
+		}
+
+		[[nodiscard]] constexpr inline const_reverse_iterator rend() const
+		{
+			return crend();
+		}
+#pragma endregion
 
 #pragma region UNARY_ARITHMETIC_OPERATORS
 	public:


### PR DESCRIPTION
Addresses issue #38 (a lot sooner than expected, but I didn't have much time to focus on making a full feature for `Matrix` today).
---
Provides STL random_access_iterator support to `EmuMath::Vector`, allowing use of the following familiar functions:
- `begin`
- `end`
- `cbegin`
- `cend`
- `rbegin`
- `rend`
- `crbegin`
- `crend`

This provides the same `value_type` interface, and does not expose underlying reference storage, allowing it to work the same way with both value and reference Vectors as the general interface with said Vectors already worked.

The naming convention of the STL-like functions betrays the usual Emu naming convention to allow `EmuMath::Vector` to be plugged directly into any algorithms that make use of this STL syntax.