### PR TITLE
General update addition of fma

### DIFF
--- a/EmuMath/EmuMath/EmuCore/Functors/Arithmetic.h
+++ b/EmuMath/EmuMath/EmuCore/Functors/Arithmetic.h
@@ -720,6 +720,44 @@ namespace EmuCore
 			return _fmadd()(x_, y_, -z_);
 		}
 	};
+
+	template<>
+	struct do_fmsub<void, void, void>
+	{
+		private:
+		template<typename X_, typename Y_, typename Z_>
+		struct _result_with_args
+		{
+		private:
+			using _x_uq = EmuCore::TMP::remove_ref_cv_t<X_>;
+			using _y_uq = EmuCore::TMP::remove_ref_cv_t<Y_>;
+			using _z_uq = EmuCore::TMP::remove_ref_cv_t<Z_>;
+			using _to_invoke = EmuCore::do_fmsub<_x_uq, _y_uq, _z_uq>;
+			using _safe_invoke_result = EmuCore::TMP::safe_invoke_result<_to_invoke, const X_&, const Y_&, const Z_&>;
+
+		public:
+			using func_type = _to_invoke;
+			using type = typename _safe_invoke_result::type;
+			static constexpr bool is_valid = _safe_invoke_result::value;
+		};
+
+	public:
+		constexpr do_fmsub()
+		{
+		}
+
+		template
+		<
+			typename X_,
+			typename Y_,
+			typename Z_,
+			typename = std::enable_if_t<_result_with_args<X_, Y_, Z_>::is_valid>
+		>
+		constexpr inline typename _result_with_args<X_, Y_, Z_>::type operator()(const X_& x_, const Y_& y_, const Z_& z_) const
+		{
+			return typename _result_with_args<X_, Y_, Z_>::func_type()(x_, y_, z_);
+		}
+	};
 #pragma endregion
 
 #pragma region ARITHMETIC_OPERATOR_ASSIGN_FUNCTORS

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/StdFunctionChecks.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/StdFunctionChecks.h
@@ -1,0 +1,56 @@
+#ifndef EMU_CORE_TMP_STD_FUNCTION_CHECKS_H_INC_
+#define EMU_CORE_TMP_STD_FUNCTION_CHECKS_H_INC_ 1
+
+#include <cmath>
+#include <type_traits>
+
+namespace EmuCore::TMP
+{
+#pragma region CALL_CHECKS
+	template<class X_, class Y_, class Z_, typename = void>
+	struct valid_fma_args
+	{
+		static constexpr bool value = false;
+	};
+
+	template<class X_, class Y_, class Z_>
+	struct valid_fma_args<X_, Y_, Z_, std::void_t<decltype(std::fma(std::declval<X_>(), std::declval<Y_>(), std::declval<Z_>()))>>
+	{
+		static constexpr bool value = true;
+	};
+
+	template<class X_, class Y_, class Z_>
+	static constexpr bool valid_fma_args_v = valid_fma_args<X_, Y_, Z_>::value;
+#pragma endregion
+
+#pragma region INVOKE_RESULT_CHECKS
+	/// <summary>
+	/// <para> Determines the type that will result from invoke std::fma with the provided X_, Y_, Z_ argument types. </para>
+	/// <para> If the call is invalid, the type will be void. This should not be used as a validity check; for such uses, use valid_fma_args_v. </para>
+	/// </summary>
+	template<class X_, class Y_, class Z_>
+	struct fma_result
+	{
+	private:
+		template<bool Valid_>
+		struct _result_finder
+		{
+			using type = void;
+		};
+
+		template<>
+		struct _result_finder<true>
+		{
+			using type = decltype(std::fma(std::declval<X_>(), std::declval<Y_>(), std::declval<Z_>()));
+		};
+
+	public:
+		using type = typename _result_finder<valid_fma_args_v<X_, Y_, Z_>>::type;
+	};
+
+	template<class X_, class Y_, class Z_>
+	using fma_result_t = typename fma_result<X_, Y_, Z_>::type;
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -186,6 +186,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_all_matrix_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_add.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_divide.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_fmadd.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_fmsub.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_mod.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_multiply_basic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_subtract.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -170,6 +170,7 @@
     <ClInclude Include="EmuCore\TMPHelpers\OperatorChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\SafeEnumFuncs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\StdAliases.h" />
+    <ClInclude Include="EmuCore\TMPHelpers\StdFunctionChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\TimeTMP.h" />
     <ClInclude Include="EmuCore\TMPHelpers\Tuples.h" />
     <ClInclude Include="EmuCore\TMPHelpers\TypeComparators.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -527,5 +527,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_std_multiply.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuCore\TMPHelpers\StdFunctionChecks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -530,5 +530,11 @@
     <ClInclude Include="EmuCore\TMPHelpers\StdFunctionChecks.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_fmadd.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_basic_arithmetic\_matrix_fmsub.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_basic_arithmetic/_matrix_fmadd.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_basic_arithmetic/_matrix_fmadd.h
@@ -1,0 +1,697 @@
+#ifndef EMU_MATH_MATRIX_BASIC_ARITHMETIC_FMADD_H_INC_
+#define EMU_MATH_MATRIX_BASIC_ARITHMETIC_FMADD_H_INC_ 1
+
+#include "../_common_matrix_helper_includes.h"
+
+// CONTAINS:
+// --- fmadd
+// --- fmadd_range
+// --- fmadd_range_no_copy
+
+namespace EmuMath::Helpers
+{
+#pragma region FMADD_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmadd operations with the provided arguments in respective indices.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmadd
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmadd
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<bool OutColumnMajor_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMADD_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmadd
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmadd
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMADD_RANGE_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+	/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmadd in respective indices within the provided range, and copied respective elements of matrix_x_ elsewhere.</returns>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmadd_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmadd_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+#pragma endregion
+
+#pragma region FMADD_RANGE_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmadd_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmadd_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+#pragma endregion
+
+#pragma region FMADD_RANGE_NO_COPY_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+	/// <para> Indices outside of the provided range will be default-constructed. </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmadd in respective indices within the provided range, and default-constructed elements elsewhere.</returns>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmadd_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmadd_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmadd_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMADD_RANGE_NO_COPY_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmadd_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmadd_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmadd_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmadd, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMADD_OUTPUT_ASSIGNED_VARIANTS
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_. </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	template
+	<
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmadd
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		EMU_MATH_MATRIX_MUTATE_COPY_ASSIGN_TEMPLATE(EmuCore::do_fmadd, x_mat_ref, 0, OutNumColumns_, 0, OutNumRows_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_.</para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+	/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmadd_range
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		EMU_MATH_MATRIX_MUTATE_COPY_ASSIGN_RANGE_TEMPLATE(EmuCore::do_fmadd, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-add operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_. </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+	/// <para> Indices outside of the provided range will not be modified. </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-add on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmadd_range_no_copy
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		EMU_MATH_MATRIX_MUTATE_ASSIGN_TEMPLATE(EmuCore::do_fmadd, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_basic_arithmetic/_matrix_fmsub.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_basic_arithmetic/_matrix_fmsub.h
@@ -1,0 +1,697 @@
+#ifndef EMU_MATH_MATRIX_BASIC_ARITHMETIC_FMSUB_H_INC_
+#define EMU_MATH_MATRIX_BASIC_ARITHMETIC_FMSUB_H_INC_ 1
+
+#include "../_common_matrix_helper_includes.h"
+
+// CONTAINS:
+// --- fmsub
+// --- fmsub_range
+// --- fmsub_range_no_copy
+
+namespace EmuMath::Helpers
+{
+#pragma region FMSUB_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmsub operations with the provided arguments in respective indices.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmsub
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmsub
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<bool OutColumnMajor_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMSUB_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmsub
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmsub
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, x_mat_ref, 0, 0)
+		(
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMSUB_RANGE_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+	/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmsub in respective indices within the provided range, and copied respective elements of matrix_x_ elsewhere.</returns>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmsub_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmsub_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+#pragma endregion
+
+#pragma region FMSUB_RANGE_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmsub_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmsub_range
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub_range(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_COPY_RANGE_TEMPLATE
+		(
+			EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0
+		)(matrix_x_, matrix_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+#pragma endregion
+
+#pragma region FMSUB_RANGE_NO_COPY_CUSTOM_COLUMN_MAJOR_OUT
+	/// <summary>
+	/// <para>
+	///		Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_,
+	///		with output size/column-major arguments matching those of matrix_x_ if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+	/// </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+	/// <para> Indices outside of the provided range will be default-constructed. </para>
+	/// </summary>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	/// <returns>EmuMath Matrix containing the results of fmsub in respective indices within the provided range, and default-constructed elements elsewhere.</returns>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> matrix_fmsub_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_> matrix_fmsub_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		OutColumnMajor_
+	>
+	matrix_fmsub_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, OutColumnMajor_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMSUB_RANGE_NO_COPY_MATCHING_COLUMN_MAJOR_OUT
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_> matrix_fmsub_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, OutT_, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix<NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_> matrix_fmsub_range_no_copy
+	(
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, OutT_, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, std::size_t OutNumColumns_, std::size_t OutNumRows_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		OutNumColumns_,
+		OutNumRows_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutNumColumns_, OutNumRows_, x_value_uq, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		std::size_t NumColumnsX_, std::size_t NumRowsX_, typename TX_, bool ColumnMajorX_, class Y_, class Z_
+	>
+	[[nodiscard]] constexpr inline EmuMath::Matrix
+	<
+		NumColumnsX_,
+		NumRowsX_,
+		typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq,
+		ColumnMajorX_
+	>
+	matrix_fmsub_range_no_copy(const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_, Y_&& y_, Z_&& z_)
+	{
+		using x_value_uq = typename EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>::value_type_uq;
+		return EMU_MATH_MATRIX_MUTATE_TEMPLATE(EmuCore::do_fmsub, NumColumnsX_, NumRowsX_, x_value_uq, ColumnMajorX_, BeginColumn_, EndColumn_, BeginRow_, EndRow_)
+		(
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMSUB_OUTPUT_ASSIGNED_VARIANTS
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_. </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	template
+	<
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmsub
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		EMU_MATH_MATRIX_MUTATE_COPY_ASSIGN_TEMPLATE(EmuCore::do_fmsub, x_mat_ref, 0, OutNumColumns_, 0, OutNumRows_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_.</para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+	/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmsub_range
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_mat_ref = const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>&;
+		EMU_MATH_MATRIX_MUTATE_COPY_ASSIGN_RANGE_TEMPLATE(EmuCore::do_fmsub, x_mat_ref, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-subtract operation on the provided matrix_x_, using arguments y_ and z_, via the provided out_matrix_. </para>
+	/// <para> If Y_ is an EmuMath Matrix: Respective elements in matrix_x_ and y_ will be multiplied. Otherwise, all elements in matrix_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+	/// <para> Indices outside of the provided range will not be modified. </para>
+	/// </summary>
+	/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+	/// <param name="matrix_x_">: EmuMath Matrix to perform a fused multiply-subtract on.</param>
+	/// <param name="y_">: Scalar or EmuMath Matrix to multiply matrix_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+	template
+	<
+		std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+		class Y_, class Z_, typename TX_, std::size_t NumColumnsX_, std::size_t NumRowsX_, bool ColumnMajorX_,
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+	>
+	constexpr inline void matrix_fmsub_range_no_copy
+	(
+		EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_,
+		const EmuMath::Matrix<NumColumnsX_, NumRowsX_, TX_, ColumnMajorX_>& matrix_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		EMU_MATH_MATRIX_MUTATE_ASSIGN_TEMPLATE(EmuCore::do_fmsub, BeginColumn_, EndColumn_, BeginRow_, EndRow_, 0, 0)
+		(
+			out_matrix_,
+			matrix_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_basic_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_basic_arithmetic.h
@@ -3,6 +3,8 @@
 
 #include "_basic_arithmetic/_matrix_add.h"
 #include "_basic_arithmetic/_matrix_divide.h"
+#include "_basic_arithmetic/_matrix_fmadd.h"
+#include "_basic_arithmetic/_matrix_fmsub.h"
 #include "_basic_arithmetic/_matrix_mod.h"
 #include "_basic_arithmetic/_matrix_multiply_basic.h"
 #include "_basic_arithmetic/_matrix_subtract.h"

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -2527,6 +2527,388 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::matrix_multiply<preferred_floating_point, OutColumnMajor_>(*this, rhs_matrix_);
 		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-add operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmadd operations on this Matrix with the provided arguments in respective indices.</returns>
+		template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> Fmadd(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<typename OutT_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> Fmadd(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd<num_columns, num_rows, OutT_, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> Fmadd(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd<num_columns, num_rows, value_type_uq, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<class Y_, class Z_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_>
+		constexpr inline void Fmadd(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::matrix_fmadd(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-add operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+		/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmadd in respective indices within the provided range, and copied respective elements of this Matrix elsewhere.</returns>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> FmaddRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_ = is_column_major,
+			class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> FmaddRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template<std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> FmaddRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, value_type_uq, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, class Y_, class Z_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+		>
+		constexpr inline void FmaddRange(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::matrix_fmadd_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_>(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-add operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+		/// <para> Indices outside of the provided range will be default-constructed. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmadd in respective indices within the provided range, and default-constructed elements elsewhere.</returns>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> FmaddRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_ = is_column_major,
+			class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> FmaddRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template<std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> FmaddRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, value_type_uq, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		/// <summary>
+		/// <para> Outputs the result of a fused multiply-add operation on this Matrix using arguments y_ and z_, via the provided out_matrix_. </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+		/// <para> Indices outside of the provided range will not be modified. </para>
+		/// </summary>
+		/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, class Y_, class Z_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+		>
+		constexpr inline void FmaddRangeNoCopy(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmadd_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_>(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+
+
+
+
+
+
+
+
+
+
+
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-subtract operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmsub operations on this Matrix with the provided arguments in respective indices.</returns>
+		template<std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> Fmsub(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<typename OutT_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> Fmsub(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub<num_columns, num_rows, OutT_, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> Fmsub(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub<num_columns, num_rows, value_type_uq, OutColumnMajor_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<class Y_, class Z_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_>
+		constexpr inline void Fmsub(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::matrix_fmsub(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-subtract operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+		/// <para> Indices outside of the provided range will be copies of the respective indices in matrix_x_. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmsub in respective indices within the provided range, and copied respective elements of this Matrix elsewhere.</returns>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> FmsubRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_ = is_column_major,
+			class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> FmsubRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template<std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> FmsubRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, value_type_uq, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, class Y_, class Z_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+		>
+		constexpr inline void FmsubRange(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::matrix_fmsub_range<BeginColumn_, EndColumn_, BeginRow_, EndRow_>(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para>
+		///		Outputs the result of a fused multiply-subtract operation on this Matrix, using arguments y_ and z_,
+		///		with output size/column-major arguments matching those of this Matrix if not provided, and value_type_uq for its T_ argument if OutT_ is not provided.
+		/// </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-subtraction operations. </para>
+		/// <para> Indices outside of the provided range will be default-constructed. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to subtract from intermediate multiplication results.</param>
+		/// <returns>EmuMath Matrix containing the results of fmsub in respective indices within the provided range, and default-constructed elements elsewhere.</returns>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_ = value_type_uq, bool OutColumnMajor_ = is_column_major, class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_> FmsubRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, typename OutT_, bool OutColumnMajor_ = is_column_major,
+			class Y_, class Z_
+		>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, OutT_, OutColumnMajor_> FmsubRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, OutT_, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		template<std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, bool OutColumnMajor_ = is_column_major, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Matrix<num_columns, num_rows, value_type_uq, OutColumnMajor_> FmsubRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_, num_columns, num_rows, value_type_uq, OutColumnMajor_>
+			(
+				*this,
+				std::forward<Y_>(y_),
+				std::forward<Z_>(z_)
+			);
+		}
+
+		/// <summary>
+		/// <para> Outputs the result of a fused multiply-add operation on this Matrix using arguments y_ and z_, via the provided out_matrix_. </para>
+		/// <para> If Y_ is an EmuMath Matrix: Respective elements in this Matrix and y_ will be multiplied. Otherwise, all elements in this Matrix will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Matrix: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices within the provided range will contain results of respective fused multiply-addition operations. </para>
+		/// <para> Indices outside of the provided range will not be modified. </para>
+		/// </summary>
+		/// <param name="out_matrix_">: EmuMath Matrix to output to.</param>
+		/// <param name="y_">: Scalar or EmuMath Matrix to multiply this Matrix by.</param>
+		/// <param name="z_">: Scalar or EmuMath Matrix to add to intermediate multiplication results.</param>
+		template
+		<
+			std::size_t BeginColumn_, std::size_t EndColumn_, std::size_t BeginRow_, std::size_t EndRow_, class Y_, class Z_,
+			std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_
+		>
+		constexpr inline void FmsubRangeNoCopy(EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>& out_matrix_, Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::matrix_fmsub_range_no_copy<BeginColumn_, EndColumn_, BeginRow_, EndRow_>(out_matrix_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
 #pragma endregion
 
 #pragma region ARITHMETIC_ASSIGN_FUNCS

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -299,8 +299,7 @@ namespace EmuMath
 		///		Only available if this Matrix's underlying elements may be moved.
 		/// </summary>
 		/// <param name="to_move_">EmuMath Matrix to move into the newly constructed Matrix of the same type.</param>
-		template<typename = std::enable_if_t<is_move_constructible()>>
-		constexpr inline Matrix(this_type&& to_move_) : _data(std::move(to_move_._data))
+		constexpr inline Matrix(this_type&& to_move_) noexcept : _data(std::move(to_move_._data))
 		{
 		}
 
@@ -1353,6 +1352,12 @@ namespace EmuMath
 
 #pragma region ASSIGNMENT_OPERATORS
 	public:
+		constexpr inline this_type& operator=(this_type&& to_move_) noexcept
+		{
+			EmuMath::Helpers::matrix_copy(*this, std::forward<this_type>(to_move_));
+			return *this;
+		}
+
 		template
 		<
 			std::size_t RhsNumColumns_, std::size_t RhsNumRows_, typename RhsT_, bool RhsColumnMajor_,
@@ -1386,7 +1391,8 @@ namespace EmuMath
 			std::size_t RhsNumColumns_, std::size_t RhsNumRows_, typename RhsT_, bool RhsColumnMajor_,
 			typename = std::enable_if_t
 			<
-				EmuMath::Helpers::matrix_assign_copy_is_valid<this_type, EmuMath::Matrix<RhsNumColumns_, RhsNumRows_, RhsT_, RhsColumnMajor_>>()
+				EmuMath::Helpers::matrix_assign_copy_is_valid<this_type, EmuMath::Matrix<RhsNumColumns_, RhsNumRows_, RhsT_, RhsColumnMajor_>>() &&
+				!std::is_same_v<this_type, EmuMath::Matrix<RhsNumColumns_, RhsNumRows_, RhsT_, RhsColumnMajor_>>
 			>
 		>
 		constexpr inline this_type& operator=(EmuMath::Matrix<RhsNumColumns_, RhsNumRows_, RhsT_, RhsColumnMajor_>&& to_move_copy_)

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
@@ -150,7 +150,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of adding vector_lhs_ and rhs_ to the specified index range of an output vector, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be added. Otherwise, all elements in vector_lhs_ will have rhs_ added. </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> AddBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -195,7 +195,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of adding vector_lhs_ and rhs_ to the specified index range of the passed out_vector_, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be added. Otherwise, all elements in vector_lhs_ will have rhs_ added. </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> AddBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -351,7 +351,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of subtracting rhs_ from vector_lhs_ to the specified index range of an output vector, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be subtracted. Otherwise, all elements in vector_lhs_ will have rhs_ subtracted. </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> SubBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -396,7 +396,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of subtracting rhs_ from vector_lhs_ to the specified index range of the passed out_vector_, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be subtracted. Otherwise, all elements in vector_lhs_ will have rhs_ subtracted. </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> SubBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -552,7 +552,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of multiplying vector_lhs_ by rhs_ to the specified index range of an output vector, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be multiplied. Otherwise, all elements in vector_lhs_ will be multiplied by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> MulBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -597,7 +597,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of multiplying vector_lhs_ by rhs_ to the specified index range of the passed out_vector_, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be multiplied. Otherwise, all elements in vector_lhs_ will be multiplied by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> MulBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -753,7 +753,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of dividing vector_lhs_ by rhs_ to the specified index range of an output vector, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be divided. Otherwise, all elements in vector_lhs_ will be divided by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> DivBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -798,7 +798,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of dividing vector_lhs_ by rhs_ to the specified index range of the passed out_vector_, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be divided. Otherwise, all elements in vector_lhs_ will be divided by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> DivBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -954,7 +954,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of modulo-dividing vector_lhs_ by rhs_ to the specified index range of an output vector, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be divided. Otherwise, all elements in vector_lhs_ will be divided by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> ModBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -999,7 +999,7 @@ namespace EmuMath::Helpers
 	/// <summary>
 	/// <para> Outputs the results of modulo-dividing vector_lhs_ by rhs_ to the specified index range of the passed out_vector_, starting from vector_lhs_ index AddBegin_. </para>
 	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be divided. Otherwise, all elements in vector_lhs_ will be divided by rhs_. </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 	/// <para> ModBegin_: Inclusive index at which to start reading elements from vector_lhs_ (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
@@ -1034,19 +1034,19 @@ namespace EmuMath::Helpers
 	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 	/// <returns>EmuMath Vector containing the results of a fused multiply-add operation with the provided arguments.</returns>
 	template<std::size_t OutSize_, typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmadd(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
 	}
 
 	template<typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmadd(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmadd, SizeX_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
 	}
 
 	template<std::size_t OutSize_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1054,11 +1054,11 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmadd, OutSize_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
 	}
 
 	template<typename TX_, class Y_, class Z_, std::size_t SizeX_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1066,7 +1066,7 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmadd, SizeX_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
 	}
 
 	/// <summary>
@@ -1083,14 +1083,14 @@ namespace EmuMath::Helpers
 	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
 	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 	template<class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
-	constexpr inline void vector_fma(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	constexpr inline void vector_fmadd(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		EMU_MATH_VECTOR_MUTATE_REF_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_)(out_vector_, vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		EMU_MATH_VECTOR_MUTATE_REF_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_)(out_vector_, vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
 	}
 
 	/// <summary>
 	/// <para> Outputs a copy of vector_x_ as the desired EmuMath Vector type, with fused multiply-add operations performed in the provided range. </para>
-	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
 	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
 	/// <para>
 	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
@@ -1104,9 +1104,9 @@ namespace EmuMath::Helpers
 	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 	/// <returns>Copy of vector_x_, with fused multiply-addition performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
 	template<std::size_t OutSize_, typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmadd_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
 		(
 			vector_x_,
 			vector_x_,
@@ -1116,9 +1116,9 @@ namespace EmuMath::Helpers
 	}
 
 	template<typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmadd_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmadd, SizeX_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
 		(
 			vector_x_,
 			vector_x_,
@@ -1128,7 +1128,7 @@ namespace EmuMath::Helpers
 	}
 
 	template<std::size_t OutSize_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd_range
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1136,7 +1136,7 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmadd, OutSize_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
 		(
 			vector_x_,
 			vector_x_,
@@ -1146,7 +1146,7 @@ namespace EmuMath::Helpers
 	}
 
 	template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd_range
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1154,7 +1154,7 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmadd, SizeX_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
 		(
 			vector_x_,
 			vector_x_,
@@ -1165,7 +1165,7 @@ namespace EmuMath::Helpers
 
 	/// <summary>
 	/// <para> Outputs a copy of vector_x_, with fused multiply-add operations performed in the provided range, via the provided out_vector_. </para>
-	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
 	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
 	/// <para>
 	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
@@ -1179,9 +1179,9 @@ namespace EmuMath::Helpers
 	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
 	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 	template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
-	constexpr inline void vector_fma_range(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	constexpr inline void vector_fmadd_range(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
 		(
 			out_vector_,
 			vector_x_,
@@ -1196,16 +1196,16 @@ namespace EmuMath::Helpers
 	///		Outputs the results of a fused multiply-add on vector_x_ with the provided y_ and z_ arguments to the specified index range of an output vector, 
 	///		starting from index AddBegin_ within any provided input Vectors.
 	/// </para>
-	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
 	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
 	/// <para>
 	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
 	///		Otherwise, all intermediate multiplication results will have z_ added directly.
 	/// </para>
-	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
-	/// <para> FmaBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+	/// <para> FmaddBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
 	/// </summary>
 	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
 	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
@@ -1214,10 +1214,10 @@ namespace EmuMath::Helpers
 	///		EmuMath Vector of the desired OutSize_ (defaults to LhsSize_) and OutT_ (defaults to vector_lhs_'s value_type_uq), 
 	///		containing the results of fused multiply-addition in the specified index range as described, and default values outside of said range.
 	/// </returns>
-	template<std::size_t OutSize_, typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	template<std::size_t OutSize_, typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmadd_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_, OutBegin_, OutEnd_, FmaddBegin_)
 		(
 			vector_x_,
 			std::forward<Y_>(y_),
@@ -1225,10 +1225,10 @@ namespace EmuMath::Helpers
 		);
 	}
 
-	template<typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	template<typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmadd_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmadd, SizeX_, OutT_, OutBegin_, OutEnd_, FmaddBegin_)
 		(
 			vector_x_,
 			std::forward<Y_>(y_),
@@ -1236,8 +1236,8 @@ namespace EmuMath::Helpers
 		);
 	}
 
-	template<std::size_t OutSize_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range_no_copy
+	template<std::size_t OutSize_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd_range_no_copy
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1245,7 +1245,7 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq, OutBegin_, OutEnd_, FmaBegin_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmadd, OutSize_, x_value_uq, OutBegin_, OutEnd_, FmaddBegin_)
 		(
 			vector_x_,
 			std::forward<Y_>(y_),
@@ -1253,8 +1253,8 @@ namespace EmuMath::Helpers
 		);
 	}
 
-	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range_no_copy
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmadd_range_no_copy
 	(
 		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
 		Y_&& y_,
@@ -1262,7 +1262,7 @@ namespace EmuMath::Helpers
 	)
 	{
 		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
-		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq, OutBegin_, OutEnd_, FmaBegin_)
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmadd, SizeX_, x_value_uq, OutBegin_, OutEnd_, FmaddBegin_)
 		(
 			vector_x_,
 			std::forward<Y_>(y_),
@@ -1275,25 +1275,309 @@ namespace EmuMath::Helpers
 	///		Outputs the results of a fused multiply-add on vector_x_ with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
 	///		starting from index AddBegin_ within any provided input Vectors (excluding out_vector_).
 	/// </para>
-	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
 	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
 	/// <para>
 	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
 	///		Otherwise, all intermediate multiplication results will have z_ added directly.
 	/// </para>
-	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
 	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
 	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
-	/// <para> FmaBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+	/// <para> FmaddBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
 	/// </summary>
 	/// <param name="out_vector_">: EmuMath Vector to otuput to.</param>
 	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
 	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
 	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
-	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
-	constexpr inline void vector_fma_range_no_copy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fmadd_range_no_copy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
 	{
-		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmadd, OutSize_, OutT_, OutBegin_, OutEnd_, FmaddBegin_)
+		(
+			out_vector_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+#pragma endregion
+
+	#pragma region FMA_FUNCS
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-subtract operation with the provided vector_x_, y_, and z_ arguments. </para>
+	/// <para> This operation will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-subtract operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	/// <returns>EmuMath Vector containing the results of a fused multiply-subtract operation with the provided arguments.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmsub(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmsub(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmsub, SizeX_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<std::size_t OutSize_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmsub, OutSize_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<typename TX_, class Y_, class Z_, std::size_t SizeX_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fmsub, SizeX_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-subtract operation with the provided vector_x_, y_, and z_ arguments, via the provided out_vector_. </para>
+	/// <para> This operation will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-subtracted operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	template<class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fmsub(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		EMU_MATH_VECTOR_MUTATE_REF_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_)(out_vector_, vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	/// <summary>
+	/// <para> Outputs a copy of vector_x_ as the desired EmuMath Vector type, with fused multiply-subtract operations performed in the provided range. </para>
+	/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> BeginIndex_: Inclusive index at which to start fused multiply-subtracting elements. </para>
+	/// <para> EndIndex_: Exclusive index at which to stop fused multiply-subtracting elements. </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to copy, and to perform fused multiply-subtract operations on within the provided range.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	/// <returns>Copy of vector_x_, with fused multiply-subtraction performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmsub_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmsub_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmsub, SizeX_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutSize_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub_range
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmsub, OutSize_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub_range
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fmsub, SizeX_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs a copy of vector_x_, with fused multiply-subtract operations performed in the provided range, via the provided out_vector_. </para>
+	/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> BeginIndex_: Inclusive index at which to start fused multiply-subtracting elements. </para>
+	/// <para> EndIndex_: Exclusive index at which to stop fused multiply-subtracting elements. </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to copy, and to perform fused multiply-subtract operations on within the provided range.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fmsub_range(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			out_vector_,
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> 
+	///		Outputs the results of a fused multiply-subtract on vector_x_ with the provided y_ and z_ arguments to the specified index range of an output vector, 
+	///		starting from index FmsubBegin_ within any provided input Vectors.
+	/// </para>
+	/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices outside of the specified output range will be default-constructed. </para>
+	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+	/// <para> FmaddBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform fused arithmetic. </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-subtract operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	/// <returns>
+	///		EmuMath Vector of the desired OutSize_ (defaults to LhsSize_) and OutT_ (defaults to vector_lhs_'s value_type_uq), 
+	///		containing the results of fused multiply-subtraction in the specified index range as described, and default values outside of said range.
+	/// </returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmsubBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fmsub_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_, OutBegin_, OutEnd_, FmsubBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmsubBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fmsub_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmsub, SizeX_, OutT_, OutBegin_, OutEnd_, FmsubBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutSize_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmsubBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub_range_no_copy
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmsub, OutSize_, x_value_uq, OutBegin_, OutEnd_, FmsubBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmsubBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fmsub_range_no_copy
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmsub, SizeX_, x_value_uq, OutBegin_, OutEnd_, FmsubBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> 
+	///		Outputs the results of a fused multiply-subtract on vector_x_ with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
+	///		starting from index AddBegin_ within any provided input Vectors (excluding out_vector_).
+	/// </para>
+	/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+	///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+	/// </para>
+	/// <para> Indices outside of the specified output range will not be modified. </para>
+	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+	/// <para> FmsubBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform fused arithmetic. </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to otuput to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-subtract operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmsubBegin_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fmsub_range_no_copy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fmsub, OutSize_, OutT_, OutBegin_, OutEnd_, FmsubBegin_)
 		(
 			out_vector_,
 			vector_x_,

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
@@ -10,6 +10,7 @@
 // --- multiply
 // --- divide
 // --- mod
+// --- fma
 
 namespace EmuMath::Helpers
 {
@@ -1014,6 +1015,290 @@ namespace EmuMath::Helpers
 			out_vector_,
 			vector_lhs_,
 			std::forward<Rhs_>(rhs_)
+		);
+	}
+#pragma endregion
+
+#pragma region FMA_FUNCS
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-add operation with the provided vector_x_, y_, and z_ arguments. </para>
+	/// <para> This operation will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	/// <returns>EmuMath Vector containing the results of a fused multiply-add operation with the provided arguments.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<typename OutT_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<std::size_t OutSize_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	template<typename TX_, class Y_, class Z_, std::size_t SizeX_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq)(vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	/// <summary>
+	/// <para> Outputs the result of a fused multiply-add operation with the provided vector_x_, y_, and z_ arguments, via the provided out_vector_. </para>
+	/// <para> This operation will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	template<class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fma(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		EMU_MATH_VECTOR_MUTATE_REF_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_)(out_vector_, vector_x_, std::forward<Y_>(y_), std::forward<Z_>(z_));
+	}
+
+	/// <summary>
+	/// <para> Outputs a copy of vector_x_ as the desired EmuMath Vector type, with fused multiply-add operations performed in the provided range. </para>
+	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> BeginIndex_: Inclusive index at which to start fused multiply-adding elements. </para>
+	/// <para> EndIndex_: Exclusive index at which to stop fused multiply-adding elements. </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to copy, and to perform fused multiply-add operations on within the provided range.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	/// <returns>Copy of vector_x_, with fused multiply-addition performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma_range(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutSize_, std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t SizeX_, typename TX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Outputs a copy of vector_x_, with fused multiply-add operations performed in the provided range, via the provided out_vector_. </para>
+	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> BeginIndex_: Inclusive index at which to start fused multiply-adding elements. </para>
+	/// <para> EndIndex_: Exclusive index at which to stop fused multiply-adding elements. </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to copy, and to perform fused multiply-add operations on within the provided range.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fma_range(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, SizeX_, TX_, BeginIndex_, EndIndex_)
+		(
+			out_vector_,
+			vector_x_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> 
+	///		Outputs the results of a fused multiply-add on vector_x_ with the provided y_ and z_ arguments to the specified index range of an output vector, 
+	///		starting from index AddBegin_ within any provided input Vectors.
+	/// </para>
+	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+	/// <para> FmaBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+	/// </summary>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	/// <returns>
+	///		EmuMath Vector of the desired OutSize_ (defaults to LhsSize_) and OutT_ (defaults to vector_lhs_'s value_type_uq), 
+	///		containing the results of fused multiply-addition in the specified index range as described, and default values outside of said range.
+	/// </returns>
+	template<std::size_t OutSize_, typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_fma_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<typename OutT_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, OutT_> vector_fma_range_no_copy(const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, SizeX_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutSize_, std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range_no_copy
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, x_value_uq, OutBegin_, OutEnd_, FmaBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename TX_, std::size_t SizeX_, class Y_, class Z_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<SizeX_, typename EmuMath::Vector<SizeX_, TX_>::value_type_uq> vector_fma_range_no_copy
+	(
+		const EmuMath::Vector<SizeX_, TX_>& vector_x_,
+		Y_&& y_,
+		Z_&& z_
+	)
+	{
+		using x_value_uq = typename EmuMath::Vector<SizeX_, TX_>::value_type_uq;
+		return EMU_MATH_VECTOR_MUTATE_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, SizeX_, x_value_uq, OutBegin_, OutEnd_, FmaBegin_)
+		(
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
+		);
+	}
+
+	/// <summary>
+	/// <para> 
+	///		Outputs the results of a fused multiply-add on vector_x_ with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
+	///		starting from index AddBegin_ within any provided input Vectors (excluding out_vector_).
+	/// </para>
+	/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from vector_x_ * y_ is unrounded. </para>
+	/// <para> If Y_ is an EmuMath Vector: Respective elements in vector_x_ and y_ will be multiplied. Otherwise, all elements in vector_x_ will be multiplied by y_. </para>
+	/// <para>
+	///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+	///		Otherwise, all intermediate multiplication results will have z_ added directly.
+	/// </para>
+	/// <para> Indices outisde of the specified output range will not be modified. </para>
+	/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+	/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+	/// <para> FmaBegin_: Inclusive index at which to start reading elements from vector_x_ (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+	/// </summary>
+	/// <param name="out_vector_">: EmuMath Vector to otuput to.</param>
+	/// <param name="vector_x_">: EmuMath Vector to perform the fused multiply-add operation on.</param>
+	/// <param name="y_">: Scalar or EmuMath Vector to multiply vector_x_ by.</param>
+	/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+	template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, class Y_, class Z_, std::size_t SizeX_, typename TX_, std::size_t OutSize_, typename OutT_>
+	constexpr inline void vector_fma_range_no_copy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<SizeX_, TX_>& vector_x_, Y_&& y_, Z_&& z_)
+	{
+		return EMU_MATH_VECTOR_MUTATE_REF_RANGE_NO_COPY_TEMPLATE(EmuCore::do_fma, OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_)
+		(
+			out_vector_,
+			vector_x_,
+			std::forward<Y_>(y_),
+			std::forward<Z_>(z_)
 		);
 	}
 #pragma endregion

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
@@ -10,7 +10,8 @@
 // --- multiply
 // --- divide
 // --- mod
-// --- fma
+// --- fmadd
+// --- fmsub
 
 namespace EmuMath::Helpers
 {

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -2574,26 +2574,26 @@ namespace EmuMath
 		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 		/// <returns>EmuMath Vector containing the results of a fused multiply-add operation on this Vector with the provided arguments.</returns>
 		template<std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> Fma(Y_&& y_, Z_&& z_) const
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> Fmadd(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma<OutSize_, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd<OutSize_, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		template<typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Fma(Y_&& y_, Z_&& z_) const
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Fmadd(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma<size, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd<size, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		template<class Y_, class Z_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void Fma(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		constexpr inline void Fmadd(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			EmuMath::Helpers::vector_fmadd(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		/// <summary>
 		/// <para> Outputs a copy of this Vector as the desired EmuMath Vector type, with fused multiply-add operations performed in the provided range. </para>
-		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
 		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
 		/// <para>
 		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
@@ -2606,21 +2606,21 @@ namespace EmuMath
 		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
 		/// <returns>Copy of this Vector, with fused multiply-addition performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaRange(Y_&& y_, Z_&& z_) const
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaddRange(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma_range<OutSize_, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd_range<OutSize_, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaRange(Y_&& y_, Z_&& z_) const
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaddRange(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma_range<size, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd_range<size, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void FmaRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		constexpr inline void FmaddRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
 		{
-			EmuMath::Helpers::vector_fma_range<BeginIndex_, EndIndex_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			EmuMath::Helpers::vector_fmadd_range<BeginIndex_, EndIndex_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		/// <summary>
@@ -2628,16 +2628,16 @@ namespace EmuMath
 		///		Outputs the results of a fused multiply-add on this Vector with the provided y_ and z_ arguments to the specified index range of an output vector, 
 		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
 		/// </para>
-		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
 		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
 		/// <para>
 		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
 		///		Otherwise, all intermediate multiplication results will have z_ added directly.
 		/// </para>
-		/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+		/// <para> Indices outside of the specified output range will be default-constructed. </para>
 		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
 		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
-		/// <para> FmaBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+		/// <para> FmaddBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
 		/// </summary>
 		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
 		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
@@ -2645,16 +2645,16 @@ namespace EmuMath
 		///		EmuMath Vector of the desired OutSize_ (defaults to this Vector's size) and OutT_ (defaults to this Vector's value_type_uq), 
 		///		containing the results of fused multiply-addition in the specified index range as described, and default values outside of said range.
 		/// </returns>
-		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaRangeNoCopy(Y_&& y_, Z_&& z_) const
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaddRangeNoCopy(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma_range_no_copy<OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd_range_no_copy<OutSize_, OutT_, OutBegin_, OutEnd_, FmaddBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
-		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename OutT_ = value_type_uq, class Y_, class Z_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaRangeNoCopy(Y_&& y_, Z_&& z_) const
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaddRangeNoCopy(Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma_range_no_copy<size, OutT_, OutBegin_, OutEnd_, FmaBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			return EmuMath::Helpers::vector_fmadd_range_no_copy<size, OutT_, OutBegin_, OutEnd_, FmaddBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 
 		/// <summary>
@@ -2662,24 +2662,145 @@ namespace EmuMath
 		///		Outputs the results of a fused multiply-add on this Vector with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
 		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
 		/// </para>
-		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> When a fmadd operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
 		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
 		/// <para>
 		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
 		///		Otherwise, all intermediate multiplication results will have z_ added directly.
 		/// </para>
-		/// <para> Indices outisde of the specified output range will not be modified. </para>
+		/// <para> Indices outside of the specified output range will not be modified. </para>
 		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
 		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
-		/// <para> FmaBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+		/// <para> FmaddBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
 		/// </summary>
 		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
 		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
 		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
-		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void FmaRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void FmaddRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
 		{
-			return EmuMath::Helpers::vector_fma_range_no_copy<OutBegin_, OutEnd_, FmaBegin_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+			EmuMath::Helpers::vector_fmadd_range_no_copy<OutBegin_, OutEnd_, FmaddBegin_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> Outputs the result of a fused multiply-subtract operation on this Vector with the provided y_ and z_ arguments. </para>
+		/// <para> This operation will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+		/// <returns>EmuMath Vector containing the results of a fused multiply-subtract operation on this Vector with the provided arguments.</returns>
+		template<std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> Fmsub(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub<OutSize_, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Fmsub(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub<size, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void Fmsub(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::vector_fmsub(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> Outputs a copy of this Vector as the desired EmuMath Vector type, with fused multiply-subtract operations performed in the provided range. </para>
+		/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// <para> BeginIndex_: Inclusive index at which to start fused multiply-subtracting elements. </para>
+		/// <para> EndIndex_: Exclusive index at which to stop fused multiply-subtracting elements. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+		/// <returns>Copy of this Vector, with fused multiply-subtraction performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmsubRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub_range<OutSize_, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmsubRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub_range<size, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void FmsubRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::vector_fmsub_range<BeginIndex_, EndIndex_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> 
+		///		Outputs the results of a fused multiply-subtract on this Vector with the provided y_ and z_ arguments to the specified index range of an output vector, 
+		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
+		/// </para>
+		/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// <para> Indices outside of the specified output range will be default-constructed. </para>
+		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+		/// <para> FmaddBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform fused arithmetic. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+		/// <returns>
+		///		EmuMath Vector of the desired OutSize_ (defaults to this Vector's size) and OutT_ (defaults to this Vector's value_type_uq), 
+		///		containing the results of fused multiply-subtraction in the specified index range as described, and default values outside of said range.
+		/// </returns>
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmsubRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub_range_no_copy<OutSize_, OutT_, OutBegin_, OutEnd_, FmaddBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmsubRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fmsub_range_no_copy<size, OutT_, OutBegin_, OutEnd_, FmaddBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> 
+		///		Outputs the results of a fused multiply-subtract on this Vector with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
+		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
+		/// </para>
+		/// <para> When a fmsub operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ subtracted. 
+		///		Otherwise, all intermediate multiplication results will have z_ subtracted directly.
+		/// </para>
+		/// <para> Indices outside of the specified output range will not be modified. </para>
+		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+		/// <para> FmaddBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform fused arithmetic. </para>
+		/// </summary>
+		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to subtract from intermediate multiplication results.</param>
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaddBegin_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void FmsubRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::vector_fmsub_range_no_copy<OutBegin_, OutEnd_, FmaddBegin_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -2560,6 +2560,127 @@ namespace EmuMath
 		{
 			EmuMath::Helpers::vector_mod_range_no_copy<OutBegin_, OutEnd_, ModBegin_>(out_vector_, *this, std::forward<Rhs_>(rhs_));
 		}
+
+		/// <summary>
+		/// <para> Outputs the result of a fused multiply-add operation on this Vector with the provided y_ and z_ arguments. </para>
+		/// <para> This operation will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+		/// <returns>EmuMath Vector containing the results of a fused multiply-add operation on this Vector with the provided arguments.</returns>
+		template<std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> Fma(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma<OutSize_, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Fma(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma<size, OutT_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void Fma(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> Outputs a copy of this Vector as the desired EmuMath Vector type, with fused multiply-add operations performed in the provided range. </para>
+		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> BeginIndex_: Inclusive index at which to start fused multiply-adding elements. </para>
+		/// <para> EndIndex_: Exclusive index at which to stop fused multiply-adding elements. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+		/// <returns>Copy of this Vector, with fused multiply-addition performed with the provided y_ and z_ arguments as described within the specified index range.</returns>
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma_range<OutSize_, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaRange(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma_range<size, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void FmaRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			EmuMath::Helpers::vector_fma_range<BeginIndex_, EndIndex_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> 
+		///		Outputs the results of a fused multiply-add on this Vector with the provided y_ and z_ arguments to the specified index range of an output vector, 
+		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
+		/// </para>
+		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices outisde of the specified output range will be default-constructed. </para>
+		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+		/// <para> FmaBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+		/// </summary>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+		/// <returns>
+		///		EmuMath Vector of the desired OutSize_ (defaults to this Vector's size) and OutT_ (defaults to this Vector's value_type_uq), 
+		///		containing the results of fused multiply-addition in the specified index range as described, and default values outside of said range.
+		/// </returns>
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, std::size_t OutSize_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> FmaRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma_range_no_copy<OutSize_, OutT_, OutBegin_, OutEnd_, FmaBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, typename OutT_ = value_type_uq, class Y_, class Z_>
+		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> FmaRangeNoCopy(Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma_range_no_copy<size, OutT_, OutBegin_, OutEnd_, FmaBegin_>(*this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
+
+		/// <summary>
+		/// <para> 
+		///		Outputs the results of a fused multiply-add on this Vector with the provided y_ and z_ arguments to the specified index range of the provided out_vector_, 
+		///		starting from index AddBegin_ within any provided input Vectors (including this Vector).
+		/// </para>
+		/// <para> When a fma operation is performed, it will perform only one floating-point round operation; the intermediate from this_vector * y_ is unrounded. </para>
+		/// <para> If Y_ is an EmuMath Vector: Respective elements in this Vector and y_ will be multiplied. Otherwise, all elements in this Vector will be multiplied by y_. </para>
+		/// <para>
+		///		If Z_ is an EmuMath Vector: Intermediate results from each multiplication in specific indices will have the respective indices of z_ added. 
+		///		Otherwise, all intermediate multiplication results will have z_ added directly.
+		/// </para>
+		/// <para> Indices outisde of the specified output range will not be modified. </para>
+		/// <para> OutBegin_: Inclusive index at which to start writing fused arithmetic results to the output Vector. </para>
+		/// <para> OutEnd_: Exclusive index at which to stop writing fused arithmetic results to the output Vector. </para>
+		/// <para> FmaBegin_: Inclusive index at which to start reading elements from this Vector (and y_ and z_ if they are EmuMath Vectors) to perform arithmetic. </para>
+		/// </summary>
+		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
+		/// <param name="y_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
+		/// <param name="z_">: Scalar or EmuMath Vector to add to intermediate multiplication results.</param>
+		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t FmaBegin_, class Y_, class Z_, std::size_t OutSize_, typename OutT_>
+		constexpr inline void FmaRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Y_&& y_, Z_&& z_) const
+		{
+			return EmuMath::Helpers::vector_fma_range_no_copy<OutBegin_, OutEnd_, FmaBegin_>(out_vector_, *this, std::forward<Y_>(y_), std::forward<Z_>(z_));
+		}
 #pragma endregion
 
 #pragma region CONST_BITWISE_FUNCS

--- a/EmuMath/EmuMath/Tests.hpp
+++ b/EmuMath/EmuMath/Tests.hpp
@@ -499,13 +499,16 @@ namespace EmuCore::TestingHelpers
 		static constexpr bool PASS_LOOP_NUM = true;
 		static constexpr std::size_t NUM_LOOPS = 500000;
 		static constexpr bool WRITE_ALL_TIMES_TO_STREAM = false;
-		static constexpr std::string_view NAME = "Vector FMA (Manual Multiply -> Add)";
+		static constexpr std::string_view NAME = "Matrix FMS (Manual Multiply -> Sub)";
 
-		static constexpr std::size_t vec_size = 30;
-		using vector_type_arg = float;
-		using vector_type = EmuMath::Vector<vec_size, vector_type_arg>;
-		using float_type = typename vector_type::preferred_floating_point;
-		using vector_type_fp = EmuMath::Vector<vec_size, float_type>;
+		static constexpr std::size_t num_columns = 4;
+		static constexpr std::size_t num_rows = 4;
+		static constexpr bool column_major = false; // Just to appear identically to dxm in terms of where our random args are
+		using t_arg = int;
+		using out_type = EmuMath::Matrix<num_columns, num_rows, t_arg, column_major>;
+		using in_a_type = out_type;
+		using in_a_type_column_major = EmuMath::Matrix<in_a_type::num_columns, in_a_type::num_rows, in_a_type::stored_type, true>;
+		using in_b_type = t_arg;
 
 		fma_test_manual()
 		{
@@ -513,38 +516,37 @@ namespace EmuCore::TestingHelpers
 		void Prepare()
 		{
 			// RESIZES
-			out_fma.resize(NUM_LOOPS);
+			out.resize(NUM_LOOPS);
 
 			// RESERVES
 			in_x.reserve(NUM_LOOPS);
 			in_y.reserve(NUM_LOOPS);
-			in_z.reserve(NUM_LOOPS);
 
-			// FILL RESERVES
-			RngFunctor rng_ = RngFunctor(shared_fill_seed_);
-			rng_._rng.SetMinMax(-1000, 1000);
-
+			// RESERVED FILLS
+			RngFunctor rng_(shared_fill_seed_);
+			rng_._rng.SetMinMax(0, 25);
 			for (std::size_t i = 0; i < NUM_LOOPS; ++i)
 			{
-				emplace_back_vector<vec_size, vector_type_arg>(in_x, rng_);
-				emplace_back_vector<vec_size, float_type>(in_y, rng_);
-				emplace_back_vector<vec_size, float_type>(in_z, rng_);
+				//in_a.push_back(in_a_type(in_a_type_column_major(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)));
+				in_x.push_back(make_random_matrix<in_a_type>(rng_));
+				in_y.push_back(in_b_type(rng_._rng.NextReal<float>()));
+				in_z.push_back(in_b_type(rng_._rng.NextReal<float>()));
 			}
 		}
 		void operator()(std::size_t i)
 		{
-			(in_x[i] * in_y[i]).Add(out_fma[i], in_z[i]);
+			in_x[i].MultiplyBasic(in_y[i]).Subtract(out[i], in_z[i]);
 		}
 		void OnTestsOver()
 		{
 			const std::size_t i_ = RngFunctor(shared_select_seed_)._rng.NextInt<std::size_t>() % NUM_LOOPS;
-			std::cout << "FMA(\n\t" << in_x[i_] << ",\n\t" << in_y[i_] << ",\n\t" << in_z[i_] << "\n): " << out_fma[i_] << "\n\n";
+			std::cout << out[i_] << "\n\n";
 		}
 
-		std::vector<vector_type> in_x;
-		std::vector<vector_type_fp> in_y;
-		std::vector<vector_type_fp> in_z;
-		std::vector<vector_type_fp> out_fma;
+		std::vector<in_a_type> in_x;
+		std::vector<in_b_type> in_y;
+		std::vector<in_b_type> in_z;
+		std::vector<out_type> out;
 	};
 
 	struct fma_test_fused
@@ -553,13 +555,16 @@ namespace EmuCore::TestingHelpers
 		static constexpr bool PASS_LOOP_NUM = true;
 		static constexpr std::size_t NUM_LOOPS = 500000;
 		static constexpr bool WRITE_ALL_TIMES_TO_STREAM = false;
-		static constexpr std::string_view NAME = "Vector FMA (Fused)";
+		static constexpr std::string_view NAME = "Matrix FMS (Fused)";
 
-		static constexpr std::size_t vec_size = 30;
-		using vector_type_arg = float;
-		using vector_type = EmuMath::Vector<vec_size, vector_type_arg>;
-		using float_type = typename vector_type::preferred_floating_point;
-		using vector_type_fp = EmuMath::Vector<vec_size, float_type>;
+		static constexpr std::size_t num_columns = fma_test_manual::num_columns;
+		static constexpr std::size_t num_rows = fma_test_manual::num_rows;
+		static constexpr bool column_major = false; // Just to appear identically to dxm in terms of where our random args are
+		using t_arg = int;
+		using out_type = EmuMath::Matrix<num_columns, num_rows, t_arg, column_major>;
+		using in_a_type = out_type;
+		using in_a_type_column_major = EmuMath::Matrix<in_a_type::num_columns, in_a_type::num_rows, in_a_type::stored_type, true>;
+		using in_b_type = t_arg;
 
 		fma_test_fused()
 		{
@@ -567,38 +572,37 @@ namespace EmuCore::TestingHelpers
 		void Prepare()
 		{
 			// RESIZES
-			out_fma.resize(NUM_LOOPS);
+			out.resize(NUM_LOOPS);
 
 			// RESERVES
 			in_x.reserve(NUM_LOOPS);
 			in_y.reserve(NUM_LOOPS);
-			in_z.reserve(NUM_LOOPS);
 
-			// FILL RESERVES
-			RngFunctor rng_ = RngFunctor(shared_fill_seed_);
-			rng_._rng.SetMinMax(-1000, 1000);
-
+			// RESERVED FILLS
+			RngFunctor rng_(shared_fill_seed_);
+			rng_._rng.SetMinMax(0, 25);
 			for (std::size_t i = 0; i < NUM_LOOPS; ++i)
 			{
-				emplace_back_vector<vec_size, vector_type_arg>(in_x, rng_);
-				emplace_back_vector<vec_size, float_type>(in_y, rng_);
-				emplace_back_vector<vec_size, float_type>(in_z, rng_);
+				//in_a.push_back(in_a_type(in_a_type_column_major(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)));
+				in_x.push_back(make_random_matrix<in_a_type>(rng_));
+				in_y.push_back(in_b_type(rng_._rng.NextReal<float>()));
+				in_z.push_back(in_b_type(rng_._rng.NextReal<float>()));
 			}
 		}
 		void operator()(std::size_t i)
 		{
-			in_x[i].Fmadd(out_fma[i], in_y[i], in_z[i]);
+			in_x[i].Fmsub(out[i], in_y[i], in_z[i]);
 		}
 		void OnTestsOver()
 		{
 			const std::size_t i_ = RngFunctor(shared_select_seed_)._rng.NextInt<std::size_t>() % NUM_LOOPS;
-			std::cout << "FMA(\n\t" << in_x[i_] << ",\n\t" << in_y[i_] << ",\n\t" << in_z[i_] << "\n): " << out_fma[i_] << "\n\n";
+			std::cout << out[i_] << "\n\n";
 		}
 
-		std::vector<vector_type> in_x;
-		std::vector<vector_type_fp> in_y;
-		std::vector<vector_type_fp> in_z;
-		std::vector<vector_type_fp> out_fma;
+		std::vector<in_a_type> in_x;
+		std::vector<in_b_type> in_y;
+		std::vector<in_b_type> in_z;
+		std::vector<out_type> out;
 	};
 
 	// ----------- TESTS SELECTION -----------

--- a/EmuMath/EmuMath/Tests.hpp
+++ b/EmuMath/EmuMath/Tests.hpp
@@ -587,7 +587,7 @@ namespace EmuCore::TestingHelpers
 		}
 		void operator()(std::size_t i)
 		{
-			in_x[i].Fma(out_fma[i], in_y[i], in_z[i]);
+			in_x[i].Fmadd(out_fma[i], in_y[i], in_z[i]);
 		}
 		void OnTestsOver()
 		{

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -220,6 +220,8 @@ int main()
 
 	constexpr auto unequal_mat_result = EmuMath::Matrix<4, 4, float, true>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) * EmuMath::Matrix<1, 4, float, true>(1, 2, 3, 4);
 
+
+
 	std::cout << mat_result_ << "\n\n";
 
 	// ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -220,7 +220,10 @@ int main()
 
 	constexpr auto unequal_mat_result = EmuMath::Matrix<4, 4, float, true>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) * EmuMath::Matrix<1, 4, float, true>(1, 2, 3, 4);
 
-
+	runtime_mat_to_transpose = decltype(runtime_mat_to_transpose)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
+	std::cout << runtime_mat_to_transpose << "\n\n";
+	decltype(runtime_mat_to_transpose) another_(std::move(runtime_mat_to_transpose));
+	std::cout << another_ << "\n\n";
 
 	std::cout << mat_result_ << "\n\n";
 


### PR DESCRIPTION
Fused multiply-add and fused multiply-subtract functions added to Vectors and Matrices.

Additionally includes two new core functors - `EmuCore::do_fmadd` and `EmuCore::do_fmsub`.
   - `do_fmadd` uses `std::fma` when at least one argument is floating-point, and falls back to `(x * y) + z` when no arguments are floating-point.
   - `do_fmsub` doesn't have a standard library function to call. As it is far more likely that `std::fma` will be made constexpr-evaluable than inline blocks of asm, `do_fmsub` emulates the operation it names by deferring to `do_fmadd` with a negated z.
      - E.g. `do_fmsub<Args...>()(x, y, z)` is equivalent to `do_fmadd<Args...>()(x, y, -z)`.
   - These functors are not constexpr-evaluable if a fused operation is performed. This is a result of `std::fma` not being constexpr-evaluable. If a fused operation is not performed but instead emulated (such as where all 3 arguments are integral), the expression is constexpr-evaluable if:
      - `(x * y) + z` is constexpr-evaluable, in the case of `do_fmadd`
      - `(x * y) + -z` is constexpr-evaluable, in the case of `do_fmsub`