### PR TITLE
Rect

### DIFF
--- a/EmuMath/EmuMath/EmuCore/ArithmeticHelpers/CommonAlgebra.h
+++ b/EmuMath/EmuMath/EmuCore/ArithmeticHelpers/CommonAlgebra.h
@@ -1,0 +1,88 @@
+#ifndef EMU_CORE_COMMON_ALGEBRA_H_INC_
+#define EMU_CORE_COMMON_ALGEBRA_H_INC_ 1
+
+#include "CommonMath.h"
+#include "CommonValues.h"
+#include "../Functors/Arithmetic.h"
+#include "../TMPHelpers/DescriptiveEnableIf.h"
+#include "../TMPHelpers/TypeObfuscation.h"
+
+namespace EmuCore
+{
+	/// <summary>
+	/// <para> Template function to calculate the dot product of any arbitrary number of values. </para>
+	/// <para> Only invoked when at least 3 arguments are passed. </para>
+	/// <para> Requires an output type as its first template argument. </para>
+	/// </summary>
+	/// <param name="values_">All values to be used in calculation of the dot product.</param>
+	/// <returns>The dot product of all passed `values_`.</returns>
+	template<typename Out_ = void, typename...Ts_, typename = EmuCore::TMP::enable_if_min_typeargs_t<3, Ts_...>>
+	[[nodiscard]] constexpr inline decltype(auto) dot(Ts_&&...values_)
+	{
+		if constexpr (std::is_void_v<Out_>)
+		{
+			return 
+			(
+				Out_(0) + 
+				... + 
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<Ts_>::type, typename EmuCore::TMP::remove_ref_cv<Ts_>::type>()
+				(
+					EmuCore::TMP::const_lval_ref_cast<Ts_>(values_),
+					EmuCore::TMP::const_lval_ref_cast<Ts_>(values_)
+				)
+			);
+		}
+		else
+		{
+			return static_cast<Out_>
+			(
+				(
+					Out_(0) + 
+					... + 
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<Ts_>::type, typename EmuCore::TMP::remove_ref_cv<Ts_>::type>()
+					(
+						EmuCore::TMP::const_lval_ref_cast<Ts_>(values_),
+						EmuCore::TMP::const_lval_ref_cast<Ts_>(values_)
+					)
+				)
+			);
+		}		
+	}
+
+	/// <summary>
+	/// <para> Template function to calculate the dot product of 2 passed values of arbitrary types. </para>
+	/// <para> This function may be specialised for special types which may produce dot products differently (such as mathematical vectors). </para>
+	/// <para> Requires an output type as its first template argument. </para>
+	/// </summary>
+	/// <param name="a_">First item for calculating the dot product.</param>
+	/// <param name="b_">Second item for calculating the dot product.</param>
+	/// <returns>Dot product of `a_` and `b_`, which is equivalent to `(a_ * a_) + (b_ * b_)` for scalar types.</returns>
+	template<typename Out_ = void, typename A_, typename B_>
+	[[nodiscard]] constexpr inline decltype(auto) dot(A_&& a_, B_&& b_)
+	{
+		const auto& a_lval = EmuCore::TMP::const_lval_ref_cast<A_>(std::forward<A_>(a_));
+		const auto& b_lval = EmuCore::TMP::const_lval_ref_cast<B_>(std::forward<B_>(b_));
+
+		if constexpr(std::is_void_v<Out_>)
+		{
+			return EmuCore::do_add<void, void>()
+			(
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<A_>::type, typename EmuCore::TMP::remove_ref_cv<A_>::type>()(a_lval, a_lval),
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<B_>::type, typename EmuCore::TMP::remove_ref_cv<B_>::type>()(b_lval, b_lval)
+			);
+		}
+		else
+		{
+			return static_cast<Out_>
+			(
+				EmuCore::do_add<void, void>()
+				(
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<A_>::type, typename EmuCore::TMP::remove_ref_cv<A_>::type>()(a_lval, a_lval),
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<B_>::type, typename EmuCore::TMP::remove_ref_cv<B_>::type>()(b_lval, b_lval)
+				)
+			);
+		}
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/DescriptiveEnableIf.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/DescriptiveEnableIf.h
@@ -1,0 +1,37 @@
+#ifndef EMU_CORE_TMP_DESCRIPTIVE_ENABLE_IF_H_INC_
+#define EMU_CORE_TMP_DESCRIPTIVE_ENABLE_IF_H_INC_ 1
+
+#include <functional>
+#include <type_traits>
+
+namespace EmuCore::TMP
+{
+	template<std::size_t Count_>
+	struct min_arg_count {};
+
+	template<std::size_t Count_>
+	struct max_arg_count {};
+
+	template<std::size_t Min_, std::size_t Max_>
+	struct min_max_arg_count {};
+
+	template<std::size_t Min_, class...T_>
+	using enable_if_min_typeargs_t = std::enable_if_t<(sizeof...(T_) >= Min_), min_arg_count<Min_>>;
+
+	template<std::size_t Max_, class...T_>
+	using enable_if_max_typeargs_t = std::enable_if_t<(sizeof...(T_) <= Max_), max_arg_count<Max_>>;
+
+	template<std::size_t Min_, std::size_t Max_, class...T_>
+	using enable_if_min_max_typeargs_t = std::enable_if_t<(sizeof...(T_) >= Min_ &&sizeof...(T_) <= Max_), min_max_arg_count<Min_, Max_>>;
+
+	template<std::size_t Min_, auto...Vals_>
+	using enable_if_min_val_args_t = std::enable_if_t<(sizeof...(Vals_) >= Min_), min_arg_count<Min_>>;
+
+	template<std::size_t Max_, auto...Vals_>
+	using enable_if_max_val_args_t = std::enable_if_t<(sizeof...(Vals_) <= Max_), max_arg_count<Max_>>;
+
+	template<std::size_t Min_, std::size_t Max_, auto...Vals_>
+	using enable_if_min_max_val_args_t = std::enable_if_t<(sizeof...(Vals_) >= Min_ && sizeof...(Vals_) <= Max_), min_max_arg_count<Min_, Max_>>;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
@@ -442,6 +442,27 @@ namespace EmuCore::TMP
 		return static_cast<std::remove_reference_t<T_>&>(ref_);
 	}
 
+	/// <summary>
+	/// <para> Casts a reference to a const-qualified lvalue-reference. </para>
+	/// <para> This can effectively be considered an `unmove` cast, treating lvalues as lvalues and casting rvalues to lvalues. </para>
+	/// <para>
+	///		WARNING: This is for casting pre-existing, named rvalues.
+	///		Passing a new rvalue (such as `my_type(5)) will result in output of a dangling reference. 
+	/// </para>
+	/// </summary>
+	/// <param name="ref_">Reference to cast to an lvalue reference.</param>
+	/// <returns>The passed ref_ cast to a const-qualified lvalue reference.</returns>
+	template<typename T_>
+	[[nodiscard]] constexpr inline const std::remove_reference_t<T_>& const_lval_ref_cast(std::remove_reference_t<T_>& ref_)
+	{
+		return ref_;
+	}
+	template<typename T_>
+	[[nodiscard]] constexpr inline const std::remove_reference_t<T_>& const_lval_ref_cast(std::remove_reference_t<T_>&& ref_)
+	{
+		return static_cast<std::remove_reference_t<T_>&>(ref_);
+	}
+
 	/// <summary> Type used to alias type T_ as its internal type alias. Mainly for use in conditions such as `std::conditional_t&lt;bool, x, y&gt;::type`. </summary>
 	/// <typeparam name="T_">Type to be accessible by the defined type alias.</typeparam>
 	template<typename T_>

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -183,6 +183,8 @@
     <ClInclude Include="EmuCore\TMPHelpers\Values.h" />
     <ClInclude Include="EmuCore\TMPHelpers\VariadicHelpers.h" />
     <ClInclude Include="EmuMath\Colour.h" />
+    <ClInclude Include="EmuMath\Common3D.h" />
+    <ClInclude Include="EmuMath\Fast3D.h" />
     <ClInclude Include="EmuMath\FastNoise.h" />
     <ClInclude Include="EmuMath\FastVector.h" />
     <ClInclude Include="EmuMath\Matrix.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="EmuCore\TMPHelpers\TypeObfuscation.h" />
     <ClInclude Include="EmuCore\TMPHelpers\Values.h" />
     <ClInclude Include="EmuCore\TMPHelpers\VariadicHelpers.h" />
+    <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h" />
     <ClInclude Include="EmuMath\Colour.h" />
     <ClInclude Include="EmuMath\Common3D.h" />
     <ClInclude Include="EmuMath\Fast3D.h" />
@@ -277,6 +278,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -277,8 +277,10 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_conversions.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_checks.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -189,10 +189,12 @@
     <ClInclude Include="EmuMath\Noise.h" />
     <ClInclude Include="EmuMath\Quaternion.h" />
     <ClInclude Include="EmuMath\Random.h" />
+    <ClInclude Include="EmuMath\Rect.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_fast_vectors\_fast_vector_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_projections.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_perspective.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_all_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_common_quaternion_helper_includes.h" />
@@ -268,6 +270,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_std_ops\_vector_do_swap_specialisation.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_common_vector_helpers.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -119,7 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -171,7 +171,7 @@
     <ClInclude Include="EmuCore\Functors\StdOps.h" />
     <ClInclude Include="EmuCore\TestingHelpers\LoopingTestHarness.h" />
     <ClInclude Include="EmuCore\TMPHelpers\DefaultItemBases.h" />
-    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h" />
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h" />
     <ClInclude Include="EmuCore\TMPHelpers\OperatorChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\SafeEnumFuncs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\StdAliases.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -152,6 +152,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EmuCore\ArithmeticHelpers\BitHelpers.h" />
+    <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h" />
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonMath.h" />
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonValues.h" />
     <ClInclude Include="EmuCore\CommonTypes\ComparisonEnum.h" />
@@ -170,6 +171,7 @@
     <ClInclude Include="EmuCore\Functors\StdOps.h" />
     <ClInclude Include="EmuCore\TestingHelpers\LoopingTestHarness.h" />
     <ClInclude Include="EmuCore\TMPHelpers\DefaultItemBases.h" />
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\OperatorChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\SafeEnumFuncs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\StdAliases.h" />
@@ -272,7 +274,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_std_ops\_vector_do_swap_specialisation.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_common_vector_helpers.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -818,5 +818,14 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\Rect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -833,5 +833,23 @@
     <ClInclude Include="EmuMath\Fast3D.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -857,5 +857,11 @@
     <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_checks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_conversions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -848,7 +848,7 @@
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h">
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -827,5 +827,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\Common3D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\Fast3D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -851,5 +851,11 @@
     <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath/BringHelpersToEmuMathNamespace.h
+++ b/EmuMath/EmuMath/EmuMath/BringHelpersToEmuMathNamespace.h
@@ -1,0 +1,10 @@
+#ifndef EMU_MATH_BRING_HELPERS_TO_EMU_MATH_NAMESPACE_H_INC
+#define EMU_MATH_BRING_HELPERS_TO_EMU_MATH_NAMESPACE_H_INC 1
+
+namespace EmuMath
+{
+	namespace Helpers {}
+	using namespace EmuMath::Helpers;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Common3D.h
+++ b/EmuMath/EmuMath/EmuMath/Common3D.h
@@ -1,0 +1,9 @@
+#ifndef EMU_MATH_COMMON_3D_H_INC_
+#define EMU_MATH_COMMON_3D_H_INC_ 1
+
+#include "Matrix.h"
+#include "Quaternion.h"
+#include "Rect.h"
+#include "Vector.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Fast3D.h
+++ b/EmuMath/EmuMath/EmuMath/Fast3D.h
@@ -1,0 +1,7 @@
+#ifndef EMU_MATH_FAST_3D_H_INC_
+#define EMU_MATH_FAST_3D_H_INC_ 1
+
+#include "Common3D.h"
+#include "FastVector.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Rect.h
+++ b/EmuMath/EmuMath/EmuMath/Rect.h
@@ -1,0 +1,6 @@
+#ifndef EMU_MATH_RECT_H_INC_
+#define EMU_MATH_RECT_H_INC_ 1
+
+#include "_do_not_manually_include/_rect/_rect_t.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
@@ -1,0 +1,13 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_PROJECTION_ORTHO_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_PROJECTION_ORTHO_H_INC_ 1
+
+#include "../_matrix_tmp.h"
+
+namespace EmuMath::Helpers::_matrix_underlying
+{
+#pragma region GENERATION_COMPONENTS_VK_ORTHO
+	// TODO
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
@@ -67,6 +67,8 @@ namespace EmuMath::Helpers::_matrix_underlying
 		out_22 = EmuCore::do_divide<calc_fp, calc_fp>()(out_22, EmuCore::do_subtract<calc_fp, calc_fp>()(far, out_22));
 		calc_fp focal_length = static_cast<calc_fp>(std::forward<FocalLength_>(focal_length_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return OutMatrix_
 		(
 			_make_perspective_arg_vk_reverse_depth<ColumnIndices_, RowIndices_, OutMatrix_, calc_fp>
@@ -74,9 +76,10 @@ namespace EmuMath::Helpers::_matrix_underlying
 				std::forward<AspectRatio_>(aspect_ratio_),
 				out_22,
 				far,
-				focal_length
+				focal_length 
 			)...
 		);
+#pragma warning(pop)
 	}
 
 	template<class OutMatrix_, bool FovRads_, bool IsConstexpr_, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_transformations/_matrix_underlying_translate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_transformations/_matrix_underlying_translate.h
@@ -14,20 +14,19 @@ namespace EmuMath::Helpers::_matrix_underlying
 		{
 			if constexpr (ColumnIndex_ == (out_mat_uq::num_columns - 1))
 			{
-				constexpr std::size_t tuple_index = RowIndex_;
-				if constexpr (tuple_index < std::tuple_size_v<std::tuple<Args_...>>)
+				if constexpr (RowIndex_ < std::tuple_size_v<std::tuple<Args_...>>)
 				{
 					// Retrieve translation for the dimension, which will be the respective element in the tuple
 					// --- Move if not lvalue reference
 					using std::get;
-					using arg = typename std::tuple_element<tuple_index, std::tuple<Args_...>>::type;
+					using arg = typename std::tuple_element<RowIndex_, std::tuple<Args_...>>::type;
 					if constexpr (std::is_lvalue_reference_v<arg>)
 					{
-						return get<tuple_index>(args_tuple_);
+						return get<RowIndex_>(args_tuple_);
 					}
 					else
 					{
-						return std::move(get<tuple_index>(args_tuple_));
+						return std::move(get<RowIndex_>(args_tuple_));
 					}
 				}
 				else

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -1,0 +1,7 @@
+#ifndef EMU_MATH_ALL_RECT_HELPERS_H_INC_
+#define EMU_MATH_ALL_RECT_HELPERS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -2,6 +2,8 @@
 #define EMU_MATH_ALL_RECT_HELPERS_H_INC_ 1
 
 #include "_common_rect_helper_includes.h"
+#include "_rect_checks.h"
+#include "_rect_conversions.h"
 #include "_rect_get.h"
 #include "_rect_mutate.h"
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -3,5 +3,6 @@
 
 #include "_common_rect_helper_includes.h"
 #include "_rect_get.h"
+#include "_rect_mutate.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_common_rect_helper_includes.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_common_rect_helper_includes.h
@@ -1,0 +1,6 @@
+#ifndef EMU_MATH_COMMON_RECT_HELPER_INCLUDES_H_INC_
+#define EMU_MATH_COMMON_RECT_HELPER_INCLUDES_H_INC_ 1
+
+#include "../_underlying_helpers/_rect_tmp.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -1,0 +1,133 @@
+#ifndef EMU_MATH_RECT_CHECKS_H_INC_
+#define EMU_MATH_RECT_CHECKS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect has a well-formed X axis. </para>
+	/// <para> A well-formed X-axis will have a Left value less than or equal to its Right value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's X-axis is well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_has_well_formed_x(Rect_&& rect_)
+	{
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_left_result>::type;
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_right_result>::type;
+		using cmp = EmuCore::do_cmp_less_equal<get_left_uq, get_right_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return cmp()
+		(
+			std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_))),
+			std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect has a well-formed Y axis. </para>
+	/// <para> A well-formed Y-axis will have a Top value less than or equal to its Bottom value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's Y-axis is well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_has_well_formed_y(Rect_&& rect_)
+	{
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_top_result>::type;
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_bottom_result>::type;
+		using cmp = EmuCore::do_cmp_less_equal<get_left_uq, get_right_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return cmp()
+		(
+			std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_))),
+			std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_)))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect is well-formed.</para>
+	/// <para> A well-formed Rect will have a Left value less than or equal to its Right value, and a Top value less than or equal to its Bottom value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's X- and Y-axes are both well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_is_well_formed(Rect_&& rect_)
+	{
+		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
+	}
+
+	template<typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_left_result>::type;
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_top_uq = typename EmuCore::TMP::remove_ref_cv<get_top_result>::type;
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_right_result>::type;
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+		using get_bottom_uq = typename EmuCore::TMP::remove_ref_cv<get_bottom_result>::type;
+
+		using x_type = typename std::conditional<std::is_lvalue_reference_v<X_>, X_, typename rect_uq::preferred_floating_point>::type;
+		using y_type = typename std::conditional<std::is_lvalue_reference_v<Y_>, Y_, typename rect_uq::preferred_floating_point>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<x_type>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<y_type>::type;
+		x_type x = static_cast<x_type>(std::forward<X_>(x_));
+		y_type y = static_cast<y_type>(std::forward<Y_>(y_));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return
+		(
+			EmuCore::do_cmp_less_equal<get_left_uq, x_uq>()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
+			EmuCore::do_cmp_less_equal<get_top_uq, y_uq>()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
+			EmuCore::do_cmp_greater_equal<get_right_uq, x_uq>()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
+			EmuCore::do_cmp_greater_equal<get_bottom_uq, y_uq>()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
+		);
+#pragma warning(pop)
+	}
+
+	template<EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
+	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return rect_contains_point
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<0>(),
+			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<1>()
+		);
+#pragma warning(pop)
+	}
+
+	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectA_, EmuMath::TMP::EmuRect RectB_>
+	[[nodiscard]] constexpr inline bool rect_colliding_axis_aligned(RectA_&& rect_a_, RectB_&& rect_b_)
+	{
+		using cmp_less = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_less<void, void>, EmuCore::do_cmp_less_equal<void, void>>::type;
+		using cmp_greater = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_greater<void, void>, EmuCore::do_cmp_greater_equal<void, void>>::type;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return
+		(
+			cmp_less()(rect_get_left(std::forward<RectA_>(rect_a_)), rect_get_right(std::forward<RectB_>(rect_b_))) &&
+			cmp_greater()(rect_get_right(std::forward<RectA_>(rect_a_)), rect_get_left(std::forward<RectB_>(rect_b_))) &&
+			cmp_less()(rect_get_top(std::forward<RectA_>(rect_a_)), rect_get_bottom(std::forward<RectB_>(rect_b_))) &&
+			cmp_greater()(rect_get_bottom(std::forward<RectA_>(rect_a_)), rect_get_top(std::forward<RectB_>(rect_b_)))
+		);
+#pragma warning(pop)
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -65,7 +65,7 @@ namespace EmuMath::Helpers
 		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
 	}
 
-	template<typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -85,24 +85,27 @@ namespace EmuMath::Helpers
 		x_type x = static_cast<x_type>(std::forward<X_>(x_));
 		y_type y = static_cast<y_type>(std::forward<Y_>(y_));
 
+		using cmp_less = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_less<void, void>, EmuCore::do_cmp_less_equal<void, void>>::type;
+		using cmp_greater = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_greater<void, void>, EmuCore::do_cmp_greater_equal<void, void>>::type;
+
 #pragma warning(push)
 #pragma warning(disable: 26800)
 		return
 		(
-			EmuCore::do_cmp_less_equal<get_left_uq, x_uq>()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
-			EmuCore::do_cmp_less_equal<get_top_uq, y_uq>()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
-			EmuCore::do_cmp_greater_equal<get_right_uq, x_uq>()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
-			EmuCore::do_cmp_greater_equal<get_bottom_uq, y_uq>()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
+			cmp_less()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
+			cmp_less()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
+			cmp_greater()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
+			cmp_greater()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
 		);
 #pragma warning(pop)
 	}
 
-	template<EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
 	{
 #pragma warning(push)
 #pragma warning(disable: 26800)
-		return rect_contains_point
+		return rect_contains_point<IgnoreEqual_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<0>(),

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -65,6 +65,14 @@ namespace EmuMath::Helpers
 		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
 	}
 
+	/// <summary>
+	/// <para> Determines if a given point is contained within the passed Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// <para> May customise whether the point is classed as outside if on the boundaries of the Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="x_">X coordinate to check for.</param>
+	/// <param name="y_">Y coordinate to check for.</param>
+	/// <returns>True if the provided X and Y coordinates are contained within the passed Rect's boundaries.</returns>
 	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
@@ -100,6 +108,14 @@ namespace EmuMath::Helpers
 #pragma warning(pop)
 	}
 
+
+	/// <summary>
+	/// <para> Determines if a given point is contained within the passed Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// <para> May customise whether the point is classed as outside if on the boundaries of the Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+	/// <returns>True if the provided coordinates are contained within the passed Rect's boundaries.</returns>
 	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
 	{
@@ -114,6 +130,14 @@ namespace EmuMath::Helpers
 #pragma warning(pop)
 	}
 
+	/// <summary>
+	/// <para> Checks if the two passed Rects are colliding in an axis-aligned context (i.e. they are considered not rotated or warped in any way). </para>
+	/// <para> This assumes that both Rects are well-formed. </para>
+	/// <para> May customise whether a point is classed as outside if on the boundaries of a Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="rect_a_">First Rect involved in the collision check.</param>
+	/// <param name="rect_b_">Second Rect involved in the collision check.</param>
+	/// <returns>If the two passed Rects are colliding, `true`; otherwise `false`.</returns>
 	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectA_, EmuMath::TMP::EmuRect RectB_>
 	[[nodiscard]] constexpr inline bool rect_colliding_axis_aligned(RectA_&& rect_a_, RectB_&& rect_b_)
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
@@ -1,0 +1,138 @@
+#ifndef EMU_MATH_RECT_CONVERSIONS_H_INC_
+#define EMU_MATH_RECT_CONVERSIONS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	namespace _rect_underlying
+	{
+		template<std::size_t ForIndex_, std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, EmuMath::TMP::EmuRect Rect_>
+		[[nodiscard]] constexpr inline decltype(auto) _get_for_vector_index(Rect_&& rect_)
+		{
+			if constexpr (ForIndex_ == LeftIndex_)
+			{
+				using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+				return std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == TopIndex_)
+			{
+				using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+				return std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == RightIndex_)
+			{
+				using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+				return std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == BottomIndex_)
+			{
+				using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+				return std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_)));
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<ForIndex_>(),
+					"Attempted to convert an EmuMath Rect to an EmuMath Vector, but input index data provided an out-of-range index."
+				);
+			}
+		}
+	}
+
+	/// <summary>
+	/// <para> Checks if the passed indices are valid for creating an EmuMath Vector from a Rect. </para>
+	/// </summary>
+	/// <returns>If all indices are in the inclusive range 0:3 and none are duplicated, returns `true`; otherwise returns `false`.</returns>
+	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_>
+	[[nodiscard]] constexpr inline bool rect_valid_index_args_for_vector_conversion()
+	{
+		return
+		(
+			(LeftIndex_ <= 3 && TopIndex_ <= 3 && RightIndex_ <= 3 && BottomIndex_ <= 3) &&
+			EmuCore::TMP::all_consts_unique<LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>::value
+		);
+	}
+
+	/// <summary>
+	/// <para> Casts the input Rect to an EmuMath Rect of the specified type. </para>
+	/// </summary>
+	/// <param name="rect_">Rect to convert.</param>
+	/// <returns>Converted form of the input Rect.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_cast(Rect_&& rect_)
+	{
+		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return EmuMath::Rect<OutT_>
+		(
+			static_cast<out_value_uq>(std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_))))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Casts the input Rect and assigns the results to the passed output Rect. </para>
+	/// </summary>
+	/// <param name="out_rect_">EmuMath Rect to assign conversion results to.</param>
+	/// <param name="rect_">Rect to convert.</param>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline void rect_cast(EmuMath::Rect<OutT_>& out_rect_, Rect_&& rect_)
+	{
+		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_left(out_rect_), std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_top(out_rect_), std::forward<get_left_result>(rect_get_top(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_right(out_rect_), std::forward<get_left_result>(rect_get_right(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_bottom(out_rect_), std::forward<get_left_result>(rect_get_bottom(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Converts the input Rect to a 4D Vector of its 4 boundaries as specified. </para>
+	/// <para> Input indices indicate which Vector index to assign the named boundary to. These may only be non-repeating values in the inclusive range 0:3. </para>
+	/// <para> Input indices may be omitted, in which case they will default to 0, 1, 2, 3. </para>
+	/// </summary>
+	/// <param name="rect_">Rect to convert to a Vector.</param>
+	/// <returns>4D EmuMath Vector containing the 4 boundaries of the input Rect in specified indices.</returns>
+	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_as_vector(Rect_&& rect_)
+		-> std::enable_if_t<rect_valid_index_args_for_vector_conversion<LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(), EmuMath::Vector<4, OutT_>>
+	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return EmuMath::Vector<4, OutT_>
+		(
+			_rect_underlying::_get_for_vector_index<0, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<1, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<2, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<3, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_))
+		);
+#pragma warning(pop)
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> rect_as_vector(Rect_&& rect_)
+	{
+		return rect_as_vector<0, 1, 2, 3>(std::forward<Rect_>(rect_));
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -136,7 +136,8 @@ namespace EmuMath::Helpers
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
-		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<Out_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, typename rect_uq::preferred_floating_point, float>::type;
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
@@ -164,7 +165,8 @@ namespace EmuMath::Helpers
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
-		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<Out_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, typename rect_uq::preferred_floating_point, float>::type;
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -59,7 +59,11 @@ namespace EmuMath::Helpers
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
 		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return static_cast<OutT_>(sub_func()(rect_get_right(std::forward<Rect_>(rect_)), rect_get_left(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -72,7 +76,11 @@ namespace EmuMath::Helpers
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
 		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return static_cast<OutT_>(sub_func()(rect_get_bottom(std::forward<Rect_>(rect_)), rect_get_top(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -86,11 +94,14 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_size(Rect_&& rect_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Vector<2, OutT_>
 		(
 			rect_get_width<OutT_>(std::forward<Rect_>(rect_)),
 			rect_get_height<OutT_>(std::forward<Rect_>(rect_))
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -141,6 +152,9 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp right = static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_)));
 		return static_cast<Out_>
 		(
@@ -154,6 +168,7 @@ namespace EmuMath::Helpers
 				)
 			)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -170,6 +185,8 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp bottom = static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_)));
 		return static_cast<Out_>
 		(
@@ -183,6 +200,7 @@ namespace EmuMath::Helpers
 				)
 			)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -193,11 +211,14 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Vector<2, OutT_>
 		(
 			rect_get_centre_x<OutT_>(std::forward<Rect_>(rect_)),
 			rect_get_centre_y<OutT_>(std::forward<Rect_>(rect_))
 		);
+#pragma warning(pop)
 	}
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -104,18 +104,34 @@ namespace EmuMath::Helpers
 		return EmuMath::Helpers::vector_square_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>The length of the passed Rectangle.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+	/// </summary>
+	/// <returns>The length of the passed Rectangle.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_constexpr(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle in the X-axis. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>Central point of the passed Rectangle in the X-axis.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
 	{
@@ -139,6 +155,11 @@ namespace EmuMath::Helpers
 		);
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle in the Y-axis. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Height` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>Central point of the passed Rectangle in the Y-axis.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
 	{
@@ -162,6 +183,11 @@ namespace EmuMath::Helpers
 		);
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle, and outputs the X- and Y-axes' points as indices 0 and 1 (respectively) of a 2D Vector. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` and `Height` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>2D EmuMath Vector containing the passed Rect's central X and Y points in indices 0 and 1 respectively.</returns>
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -1,0 +1,176 @@
+#ifndef EMU_MATH_RECT_GET_H_INC_
+#define EMU_MATH_RECT_GET_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `left` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the X coordinate of left corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_left(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Left();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `right` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the X coordinate of right corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_right(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Right();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `top` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the Y coordinate of top corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_top(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Top();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `bottom` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the Y coordinate of bottom corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_bottom(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Bottom();
+	}
+
+	/// <summary>
+	/// <para> Calculates the width of the passed Rect based on the distance between its left and right points. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>The width of the passed Rect, based on `Right - Left`.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline OutT_ rect_get_width(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+		return static_cast<OutT_>(sub_func()(rect_get_right(std::forward<Rect_>(rect_)), rect_get_left(std::forward<Rect_>(rect_))));
+	}
+
+	/// <summary>
+	/// <para> Calculates the height of the passed Rect based on the distance between its top and bottom points. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>The height of the passed Rect, based on `Bottom - Top`.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline OutT_ rect_get_height(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+		return static_cast<OutT_>(sub_func()(rect_get_bottom(std::forward<Rect_>(rect_)), rect_get_top(std::forward<Rect_>(rect_))));
+	}
+
+	/// <summary>
+	/// <para>
+	///		Calculates the width of the passed Rect based on the distance between its left and right points, 
+	///		and its height based on the distance between its top and bottom points.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>2D Vector containing the width of the passed Rect in index 0, and its height in index 1.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_size(Rect_&& rect_)
+	{
+		return EmuMath::Vector<2, OutT_>
+		(
+			rect_get_width<OutT_>(std::forward<Rect_>(rect_)),
+			rect_get_height<OutT_>(std::forward<Rect_>(rect_))
+		);
+	}
+
+	/// <summary>
+	/// <para> Calculates the squared length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>The squared length of the passed Rectangle.</returns>
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_squared(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_square_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_constexpr(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp right = static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_)));
+		return static_cast<Out_>
+		(
+			sub_func()
+			(
+				right,
+				div_func()
+				(
+					sub_func()(right, static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)))),
+					calc_fp(2)
+				)
+			)
+		);
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp bottom = static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_)));
+		return static_cast<Out_>
+		(
+			sub_func()
+			(
+				bottom,
+				div_func()
+				(
+					sub_func()(bottom, static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)))),
+					calc_fp(2)
+				)
+			)
+		);
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
+	{
+		return EmuMath::Vector<2, OutT_>
+		(
+			rect_get_centre_x<OutT_>(std::forward<Rect_>(rect_)),
+			rect_get_centre_y<OutT_>(std::forward<Rect_>(rect_))
+		);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
@@ -1,0 +1,344 @@
+#ifndef EMU_MATH_RECT_MUTATE_H_INC_
+#define EMU_MATH_RECT_MUTATE_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="centre_x_">Point in the X-axis to centre the new Rect on.</param>
+	/// <param name="centre_y_">Point in the Y-axis to centre the new Rect on.</param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, X_&& centre_x_, Y_&& centre_y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp x = static_cast<calc_fp>(std::forward<X_>(centre_x_));
+		calc_fp y = static_cast<calc_fp>(std::forward<Y_>(centre_y_));
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(x, width_div_2),
+			sub_func()(y, height_div_2),
+			add_func()(x, width_div_2),
+			add_func()(y, height_div_2)
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="vector_centre_2d_">
+	///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+	/// </param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuVector CentreVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, CentreVector_&& vector_centre_2d_)
+	{
+		return rect_make_centred<OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<0>(),
+			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided point in both the X- and Y-axes. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="shared_centre_x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+	template<typename OutT_, typename ScalarSharedCentre_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_make_centred(Rect_&& rect_, ScalarSharedCentre_&& shared_centre_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScalarSharedCentre_>, EmuMath::Rect<OutT_>>
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using centre_uq = typename EmuCore::TMP::remove_ref_cv<ScalarSharedCentre_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, centre_uq, out_fp, in_fp>::type;
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_)); 
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(x_and_y, width_div_2),
+			sub_func()(x_and_y, height_div_2),
+			add_func()(x_and_y, width_div_2),
+			add_func()(x_and_y, height_div_2)
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
+	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
+	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		// Central values start as value in of the boundary in the negative direction
+		calc_fp centre_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
+		calc_fp centre_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
+
+		// Calculate half-sizes manually (in case moves were used above)
+		// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
+		calc_fp half_height = div_func()(sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), centre_y), calc_fp(2));
+		calc_fp half_width = div_func()(sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), centre_x), calc_fp(2));
+
+		// Actually centre these values
+		centre_x = add_func()(centre_x, half_width);
+		centre_y = add_func()(centre_y, half_height);
+
+		// Scale half-sizes and then apply them to the centres to make new boundaries
+		half_height = mul_func()(half_height, static_cast<calc_fp>(std::forward<Y_>(scale_y_)));
+		half_width = mul_func()(half_width, static_cast<calc_fp>(std::forward<X_>(scale_x_)));
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(centre_x, half_width),
+			sub_func()(centre_y, half_height),
+			add_func()(centre_x, half_width),
+			add_func()(centre_y, half_height)
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
+	/// <returns>The passed Rect scaled by the provided factors in all axes, with the same central point.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuVector ScaleVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
+	{
+		return rect_scale<OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+	template<typename OutT_, typename ScaleScalar_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_scale(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+	{
+		const auto& scale_x_and_y_lval = EmuCore::TMP::const_lval_ref_cast<ScaleScalar_>(std::forward<ScaleScalar_>(scale_x_and_y_));
+		return rect_scale<OutT_>(std::forward<Rect_>(rect_), scale_x_and_y_lval, scale_x_and_y_lval);
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
+	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
+	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
+	{
+		if constexpr (XAnchorDirection_ == 0 && YAnchorDirection_ == 0)
+		{
+			return rect_scale<OutT_>(std::forward<Rect_>(rect_), std::forward<X_>(scale_x_), std::forward<Y_>(scale_y_));
+		}
+		else
+		{
+			using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+			using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+			using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+			using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+			using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+			using in_fp = typename rect_uq::preferred_floating_point;
+			using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+
+			using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+			using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+			using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
+			using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+			// Central values start as value of the boundary in the negative direction
+			calc_fp anchored_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
+			calc_fp anchored_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
+
+			// Calculate sizes manually (in case moves were used above)
+			// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
+			// --- Respective sizes will be halved later for anchors in the positive direction
+			calc_fp height = sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), anchored_y);
+			calc_fp width = sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), anchored_x);
+
+			// Actually anchor these values, and update sizes to correctly calculate end results
+			// --- No need to modify if anchor direction is negative, as we are already bound to that anchor with the correct width for calculation
+			if constexpr (XAnchorDirection_ >= 0)
+			{
+				if constexpr (XAnchorDirection_ == 0)
+				{
+					width = div_func()(width, calc_fp(2));
+				}
+				anchored_x = add_func()(anchored_x, width);
+			}
+
+			if constexpr (YAnchorDirection_ >= 0)
+			{
+				if constexpr (YAnchorDirection_ == 0)
+				{
+					height = div_func()(height, calc_fp(2));
+				}
+				anchored_y = add_func()(anchored_y, height);
+			}
+
+			// Scale sizes and then apply them to the centres to make new boundaries
+			height = mul_func()(height, static_cast<calc_fp>(std::forward<Y_>(scale_y_)));
+			width = mul_func()(width, static_cast<calc_fp>(std::forward<X_>(scale_x_)));
+
+			// Declare output boundaries as their anchors
+			calc_fp left = anchored_x;
+			calc_fp top = anchored_y;
+			calc_fp right = anchored_x;
+			calc_fp bottom = anchored_y;
+
+			// Follows the pattern:
+			// --- Negative boundaries need respective size subtracted with non-negative anchors, otherwise ready
+			// --- Positive boundaries need respective size added with centred or negative anchors, otherwise ready
+			if constexpr (XAnchorDirection_ >= 0)
+			{
+				left = sub_func()(left, width);
+			}
+
+			if constexpr (YAnchorDirection_ >= 0)
+			{
+				top = sub_func()(top, height);
+			}
+
+			if constexpr (XAnchorDirection_ <= 0)
+			{
+				right = add_func()(right, width);
+			}
+
+			if constexpr (YAnchorDirection_ <= 0)
+			{
+				bottom = add_func()(bottom, height);
+			}
+
+			return EmuMath::Rect<OutT_>
+			(
+				std::move(left),
+				std::move(top),
+				std::move(right),
+				std::move(bottom)
+			);
+		}
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuMath::TMP::EmuVector ScaleVector_,  EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
+	{
+		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
+	/// <returns>The passed Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename ScaleScalar_,  EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_scale_anchored(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+	{
+		const auto& scale_x_and_y_lval = EmuCore::TMP::const_lval_ref_cast<ScaleScalar_>(std::forward<ScaleScalar_>(scale_x_and_y_));
+		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(std::forward<Rect_>(rect_), scale_x_and_y_lval, scale_x_and_y_lval);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
@@ -34,6 +34,8 @@ namespace EmuMath::Helpers
 		calc_fp x = static_cast<calc_fp>(std::forward<X_>(centre_x_));
 		calc_fp y = static_cast<calc_fp>(std::forward<Y_>(centre_y_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Rect<OutT_>
 		(
 			sub_func()(x, width_div_2),
@@ -41,6 +43,7 @@ namespace EmuMath::Helpers
 			add_func()(x, width_div_2),
 			add_func()(y, height_div_2)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -55,12 +58,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector CentreVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, CentreVector_&& vector_centre_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_make_centred<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<0>(),
 			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -85,9 +91,12 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
 		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
-		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_)); 
+		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_));
+#pragma warning(pop)
 
 		return EmuMath::Rect<OutT_>
 		(
@@ -126,6 +135,8 @@ namespace EmuMath::Helpers
 		using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		// Central values start as value in of the boundary in the negative direction
 		calc_fp centre_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
 		calc_fp centre_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
@@ -134,6 +145,7 @@ namespace EmuMath::Helpers
 		// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
 		calc_fp half_height = div_func()(sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), centre_y), calc_fp(2));
 		calc_fp half_width = div_func()(sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), centre_x), calc_fp(2));
+#pragma warning(pop)
 
 		// Actually centre these values
 		centre_x = add_func()(centre_x, half_width);
@@ -165,12 +177,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector ScaleVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_scale<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -226,6 +241,8 @@ namespace EmuMath::Helpers
 			using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
 			using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 			// Central values start as value of the boundary in the negative direction
 			calc_fp anchored_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
 			calc_fp anchored_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
@@ -235,6 +252,7 @@ namespace EmuMath::Helpers
 			// --- Respective sizes will be halved later for anchors in the positive direction
 			calc_fp height = sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), anchored_y);
 			calc_fp width = sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), anchored_x);
+#pragma warning(pop)
 
 			// Actually anchor these values, and update sizes to correctly calculate end results
 			// --- No need to modify if anchor direction is negative, as we are already bound to that anchor with the correct width for calculation
@@ -313,12 +331,15 @@ namespace EmuMath::Helpers
 	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuMath::TMP::EmuVector ScaleVector_,  EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -368,6 +389,8 @@ namespace EmuMath::Helpers
 		calc_type x = static_cast<calc_type>(std::forward<X_>(x_));
 		calc_type y = static_cast<calc_type>(std::forward<Y_>(y_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Rect<OutT_>
 		(
 			add_func()(rect_get_left(std::forward<Rect_>(rect_)), x),
@@ -375,6 +398,7 @@ namespace EmuMath::Helpers
 			add_func()(rect_get_right(std::forward<Rect_>(rect_)), x),
 			add_func()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -388,12 +412,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector TranslationVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_translate(Rect_&& rect_, TranslationVector_&& translation_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_translate<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<TranslationVector_>(translation_vector_2d_).template AtTheoretical<0>(),
 			std::forward<TranslationVector_>(translation_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -412,10 +439,13 @@ namespace EmuMath::Helpers
 		using add_func = EmuCore::do_add<in_value_uq, in_value_uq>;
 		using sub_func = EmuCore::do_subtract<in_value_uq, in_value_uq>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		in_value_uq left = rect_get_left(std::forward<Rect_>(rect_));
 		in_value_uq top = rect_get_top(std::forward<Rect_>(rect_));
 		in_value_uq right = rect_get_right(std::forward<Rect_>(rect_));
 		in_value_uq bottom = rect_get_bottom(std::forward<Rect_>(rect_));
+#pragma warning(pop)
 
 		// If a direction is 0, there is no reflection in that axis and thus boundaries remain the same
 		// --- If reflecting in negative direction, negative boundary has size subtracted and positive boundary becomes old negative boundary
@@ -477,10 +507,13 @@ namespace EmuMath::Helpers
 		using add_func = EmuCore::do_add<in_value_uq, in_value_uq>;
 		using sub_func = EmuCore::do_subtract<in_value_uq, in_value_uq>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		in_value_uq left = rect_get_left(std::forward<Rect_>(rect_));
 		in_value_uq top = rect_get_top(std::forward<Rect_>(rect_));
 		in_value_uq right = rect_get_right(std::forward<Rect_>(rect_));
 		in_value_uq bottom = rect_get_bottom(std::forward<Rect_>(rect_));
+#pragma warning(pop)
 
 		// If a direction is 0, there is no reflection in that axis and thus boundaries remain the same
 		// --- If reflecting in negative direction, negative boundary has size subtracted and positive boundary becomes old negative boundary

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -773,10 +773,10 @@ namespace EmuMath
 		/// <param name="x_">X coordinate to check for.</param>
 		/// <param name="y_">Y coordinate to check for.</param>
 		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
-		template<typename X_, typename Y_>
+		template<bool IgnoreEqual_ = true, typename X_, typename Y_>
 		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
 		{
-			return EmuMath::Helpers::rect_contains_point(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
+			return EmuMath::Helpers::rect_contains_point<IgnoreEqual_>(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
 		}
 
 		/// <summary>
@@ -785,10 +785,10 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
 		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
-		template<EmuMath::TMP::EmuVector PointVector_>
+		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_>
 		[[nodiscard]] constexpr inline bool ContainsPoint(PointVector_&& point_vector_2d_) const
 		{
-			return EmuMath::Helpers::rect_contains_point(*this, std::forward<PointVector_>(point_vector_2d_));
+			return EmuMath::Helpers::rect_contains_point<IgnoreEqual_>(*this, std::forward<PointVector_>(point_vector_2d_));
 		}
 
 		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectB_>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -116,6 +116,20 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region CONST_ARITHMETIC_OPERATORS
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> operator*(const preferred_floating_point& rhs_scale_) const
+		{
+			return Scale<OutT_>(rhs_scale_, rhs_scale_);
+		}
+
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> operator*(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		{
+			return Scale<OutT_>(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
 #pragma region ACCESSORS
 	private:
 		template<std::size_t Index_, std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
@@ -535,6 +549,79 @@ namespace EmuMath
 		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
 		{
 			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
+#pragma region CONST_ARITHMETIC_FUNCS
+	public:
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
+		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& scale_x_, const preferred_floating_point& scale_y_) const
+		{
+			using add_func = EmuCore::do_add<preferred_floating_point, preferred_floating_point>;
+			using sub_func = EmuCore::do_subtract<preferred_floating_point, preferred_floating_point>;
+			using mul_func = EmuCore::do_multiply<preferred_floating_point, preferred_floating_point>;
+			using div_func = EmuCore::do_divide<preferred_floating_point, preferred_floating_point>;
+
+			preferred_floating_point width = Width<preferred_floating_point>();
+			preferred_floating_point height = Height<preferred_floating_point>();
+
+			preferred_floating_point centre_y = add_func()(Top(), div_func()(height, preferred_floating_point(2)));
+			preferred_floating_point centre_x = add_func()(Left(), div_func()(width, preferred_floating_point(2)));
+
+			// Set width and height to half of new width and height; these are subtracted/added from centres to form begin/end boundaries
+			width = div_func()(mul_func()(width, scale_x_), preferred_floating_point(2));
+			height = div_func()(mul_func()(height, scale_y_), preferred_floating_point(2));
+
+			return EmuMath::Rect<OutT_>
+			(
+				sub_func()(centre_x, width),
+				sub_func()(centre_y, height),
+				add_func()(centre_x, width),
+				add_func()(centre_y, height)
+			);
+		}
+
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="shared_scale_">Scale to apply to this Rect's width and height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& shared_scale_) const
+		{
+			return Scale(shared_scale_, shared_scale_);
+		}
+
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y and theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		{
+			return Scale(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_RECT_T_H_INC_
 #define EMU_MATH_RECT_T_H_INC_ 1
 
+#include "_helpers/_all_rect_helpers.h"
 #include "../../Vector.h"
 
 namespace EmuMath
@@ -133,6 +134,15 @@ namespace EmuMath
 
 #pragma region ASSIGNMENT_FUNCS
 	public:
+		/// <summary>
+		/// <para> Sets this Rectangle's boundaries to the respective passed values. </para>
+		/// <para> If `left_` is greater than `right_`, or `top_` is greater than `bottom_`, this makes the Rect ill-formed. </para>
+		/// <para> Rectangles exist in a space where the origin point (0, 0) is in the top-left corner. </para>
+		/// </summary>
+		/// <param name="left_">X-coordinate of the leftmost boundary of the Rectangle.</param>
+		/// <param name="top_">Y-coordinate of the topmost boundary of the Rectangle.</param>
+		/// <param name="right_">X-coordinate of the rightmost boundary of the Rectangle.</param>
+		/// <param name="bottom_">Y-coordinate of the bottommost boundary of the Rectangle.</param>
 		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
 		constexpr inline void Set(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
 		{
@@ -282,26 +292,31 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the X coordinate of left corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Left()
+		[[nodiscard]] constexpr inline value_type& Left() &
 		{
 			return _left_top_right_bottom.template at<_left_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Left() const
+		[[nodiscard]] constexpr inline const value_type& Left() const&
 		{
 			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		[[nodiscard]] constexpr inline value_type&& Left() &&
+		{
+			return std::move(_left_top_right_bottom.template at<_left_index>());
 		}
 
 		/// <summary>
 		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the X coordinate of right corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Right()
+		[[nodiscard]] constexpr inline value_type& Right() &
 		{
 			return _left_top_right_bottom.template at<_right_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Right() const
+		[[nodiscard]] constexpr inline const value_type& Right() const&
 		{
 			return _left_top_right_bottom.template at<_right_index>();
 		}
@@ -310,12 +325,12 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the Y coordinate of top corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Top()
+		[[nodiscard]] constexpr inline value_type& Top() &
 		{
 			return _left_top_right_bottom.template at<_top_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Top() const
+		[[nodiscard]] constexpr inline const value_type& Top() const&
 		{
 			return _left_top_right_bottom.template at<_top_index>();
 		}
@@ -324,12 +339,12 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the Y coordinate of bottom corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Bottom()
+		[[nodiscard]] constexpr inline value_type& Bottom() &
 		{
 			return _left_top_right_bottom.template at<_bottom_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Bottom() const
+		[[nodiscard]] constexpr inline const value_type& Bottom() const&
 		{
 			return _left_top_right_bottom.template at<_bottom_index>();
 		}
@@ -343,7 +358,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ Width() const
 		{
-			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Right(), Left()));
+			return EmuMath::Helpers::rect_get_width<Out_>(*this);
 		}
 
 		/// <summary>
@@ -355,7 +370,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ Height() const
 		{
-			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Bottom(), Top()));
+			return EmuMath::Helpers::rect_get_height<Out_>(*this);
 		}
 
 		/// <summary>
@@ -368,7 +383,7 @@ namespace EmuMath
 		template<typename OutT_ = value_type_uq>
 		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Size() const
 		{
-			return EmuMath::Vector<2, OutT_>(Width(), Height());
+			return EmuMath::Helpers::rect_get_size<OutT_>(*this);
 		}
 
 		/// <summary>
@@ -380,7 +395,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ DiagonalSquaredLength() const
 		{
-			return EmuMath::Helpers::vector_square_magnitude<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length_squared<Out_>(*this);
 		}
 
 		/// <summary>
@@ -393,7 +408,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ DiagonalLengthConstexpr() const
 		{
-			return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length_constexpr<Out_>(*this);
 		}
 
 		/// <summary>
@@ -405,7 +420,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ DiagonalLength() const
 		{
-			return EmuMath::Helpers::vector_magnitude<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length<Out_>(*this);
 		}
 
 		/// <summary>
@@ -417,11 +432,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ CentralX() const
 		{
-			return EmuCore::do_add<Out_, Out_>()
-			(
-				static_cast<Out_>(Left()),
-				EmuCore::do_divide<Out_, Out_>()(Width<Out_>(), Out_(2))
-			);
+			return EmuMath::Helpers::rect_get_centre_x<Out_>(*this);
 		}
 
 		/// <summary>
@@ -433,11 +444,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ CentralY() const
 		{
-			return EmuCore::do_add<Out_, Out_>()
-			(
-				static_cast<Out_>(Top()),
-				EmuCore::do_divide<Out_, Out_>()(Height<Out_>(), Out_(2))
-			);
+			return EmuMath::Helpers::rect_get_centre_y<Out_>(*this);
 		}
 
 		/// <summary>
@@ -449,7 +456,7 @@ namespace EmuMath
 		template<typename OutT_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Centre() const
 		{
-			return EmuMath::Vector<2, OutT_>(CentralX<OutT_>(), CentralY<OutT_>());
+			return EmuMath::Helpers::rect_get_centre<OutT_>(*this);
 		}
 
 		/// <summary>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -502,6 +502,42 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region CONTAINS_CHECKS
+	public:
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="x_">X coordinate to check for.</param>
+		/// <param name="y_">Y coordinate to check for.</param>
+		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
+		template<typename X_, typename Y_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
+		{
+			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
+			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
+			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
+			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
+			return
+			(
+				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
+				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
+			);
+		}
+
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
+		template<std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
+		{
+			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
 	private:
 		_underlying_vector _left_top_right_bottom;
 	};

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -545,107 +545,6 @@ namespace EmuMath
 #pragma endregion
 
 #pragma region MUTATIONS
-	public:
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
-		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
-		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
-		{
-			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
-			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
-			OutT_ x = static_cast<OutT_>(std::forward<X_>(x_));
-			OutT_ y = static_cast<OutT_>(std::forward<Y_>(y_));
-			return Rect<OutT_>
-			(
-				EmuCore::do_subtract<OutT_, OutT_>()(x, width_div_2),
-				EmuCore::do_subtract<OutT_, OutT_>()(y, height_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x, width_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(y, height_div_2)
-			);
-		}
-
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_and_y_vector_">
-		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
-		/// </param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(const EmuMath::Vector<VecSize_, VecT_>& x_and_y_vector_) const
-		{
-			return MakeCentred(x_and_y_vector_.template AtTheoretical<0>(), x_and_y_vector_.template AtTheoretical<1>());
-		}
-
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
-		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
-		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
-			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
-		{
-			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
-			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
-			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
-			return Rect<OutT_>
-			(
-				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
-				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
-			);
-		}
-#pragma endregion
-
-#pragma region CONTAINS_CHECKS
-	public:
-		/// <summary>
-		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
-		/// <para> This assumes that the Rect is well-formed. </para>
-		/// </summary>
-		/// <param name="x_">X coordinate to check for.</param>
-		/// <param name="y_">Y coordinate to check for.</param>
-		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
-		template<typename X_, typename Y_>
-		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
-		{
-			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
-			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
-			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
-			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
-			return
-			(
-				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
-				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
-			);
-		}
-
-		/// <summary>
-		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
-		/// <para> This assumes that the Rect is well-formed. </para>
-		/// </summary>
-		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
-		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
-		template<std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
-		{
-			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
-		}
-#pragma endregion
-
-#pragma region CONST_ARITHMETIC_FUNCS
 	private:
 		template<std::int32_t Direction_>
 		[[nodiscard]] constexpr inline decltype(auto) _get_reflected_left() const
@@ -755,41 +654,88 @@ namespace EmuMath
 
 	public:
 		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
+		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
+		{
+			return EmuMath::Helpers::rect_make_centred<OutT_>(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_vector_">
+		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+		/// </param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector CentreVector_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(CentreVector_&& x_and_y_vector_) const
+		{
+			return EmuMath::Helpers::rect_make_centred<OutT_>(*this, std::forward<CentreVector_>(x_and_y_vector_));
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
+		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
+			);
+		}
+		
+		/// <summary>
 		/// <para>
 		///		Creates a copy of this Rect scaled about its centre, 
 		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
 		/// </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
 		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
 		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
 		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& scale_x_, const preferred_floating_point& scale_y_) const
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(X_&& scale_x_, Y_&& scale_y_) const
 		{
-			using add_func = EmuCore::do_add<preferred_floating_point, preferred_floating_point>;
-			using sub_func = EmuCore::do_subtract<preferred_floating_point, preferred_floating_point>;
-			using mul_func = EmuCore::do_multiply<preferred_floating_point, preferred_floating_point>;
-			using div_func = EmuCore::do_divide<preferred_floating_point, preferred_floating_point>;
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<X_>(scale_x_), std::forward<Y_>(scale_y_));
+		}
 
-			preferred_floating_point width = Width<preferred_floating_point>();
-			preferred_floating_point height = Height<preferred_floating_point>();
-
-			preferred_floating_point centre_y = add_func()(Top(), div_func()(height, preferred_floating_point(2)));
-			preferred_floating_point centre_x = add_func()(Left(), div_func()(width, preferred_floating_point(2)));
-
-			// Set width and height to half of new width and height; these are subtracted/added from centres to form begin/end boundaries
-			width = div_func()(mul_func()(width, scale_x_), preferred_floating_point(2));
-			height = div_func()(mul_func()(height, scale_y_), preferred_floating_point(2));
-
-			return EmuMath::Rect<OutT_>
-			(
-				sub_func()(centre_x, width),
-				sub_func()(centre_y, height),
-				add_func()(centre_x, width),
-				add_func()(centre_y, height)
-			);
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(ScaleVector_&& scale_vector_2d_) const
+		{
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
 		}
 
 		/// <summary>
@@ -798,30 +744,74 @@ namespace EmuMath
 		///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
 		/// </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
-		/// <param name="shared_scale_">Scale to apply to this Rect's width and height.</param>
+		/// <param name="scale_x_and_y_">Scale to apply to this Rect's width and height.</param>
 		/// <returns>This Rect scaled by the provided factor in all axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& shared_scale_) const
+		template<typename OutT_ = preferred_floating_point, typename ScaleScalar_>
+		[[nodiscard]] constexpr inline auto Scale(ScaleScalar_&& scale_x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
 		{
-			return Scale(shared_scale_, shared_scale_);
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleScalar_>(scale_x_and_y_));
 		}
 
 		/// <summary>
-		/// <para>
-		///		Creates a copy of this Rect scaled about its centre, 
-		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
-		/// </para>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
-		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
-		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
+		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> ScaleAnchored(X_&& scale_x_, Y_&& scale_y_) const
 		{
-			return Scale(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
+			(
+				*this,
+				std::forward<X_>(scale_x_),
+				std::forward<Y_>(scale_y_)
+			);
+		}
+
+		/// <summary>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> ScaleAnchored(ScaleVector_&& scale_vector_2d_) const
+		{
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
+		}
+
+		/// <summary>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="scale_x_and_y_">Scale to apply to this Rect's width and height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, typename ScaleScalar_>
+		[[nodiscard]] constexpr inline auto ScaleAnchored(ScaleScalar_&& scale_x_and_y_)
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+		{
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(*this, std::forward<ScaleScalar_>(scale_x_and_y_));
 		}
 
 		/// <summary>
@@ -898,6 +888,45 @@ namespace EmuMath
 				std::move(get<1>(top_bottom))
 			);
 		}
+#pragma endregion
+
+#pragma region CONTAINS_CHECKS
+	public:
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="x_">X coordinate to check for.</param>
+		/// <param name="y_">Y coordinate to check for.</param>
+		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
+		template<typename X_, typename Y_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
+		{
+			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
+			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
+			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
+			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
+			return
+			(
+				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
+				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
+			);
+		}
+
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
+		template<std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
+		{
+			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
+#pragma region CONST_ARITHMETIC_FUNCS
 #pragma endregion
 
 	private:

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -71,7 +71,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="size_">Size of the square to create the Rect as.</param>
 		template<typename Size_>
-		constexpr inline Rect(Size_&& size_) :
+		explicit constexpr inline Rect(Size_&& size_) :
 			_left_top_right_bottom(_make_data(std::forward<Size_>(size_)))
 		{
 		}
@@ -105,7 +105,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_copy_">Rect of a different type to copy/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(const EmuMath::Rect<ToCopyT_>& to_copy_) :
+		explicit constexpr inline Rect(const EmuMath::Rect<ToCopyT_>& to_copy_) :
 			_left_top_right_bottom(_make_data(to_copy_.Left(), to_copy_.Top(), to_copy_.Right(), to_copy_.Bottom()))
 		{
 		}
@@ -115,7 +115,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_copy_">Rect of a different type to copy/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(EmuMath::Rect<ToCopyT_>& to_copy_) :
+		explicit constexpr inline Rect(EmuMath::Rect<ToCopyT_>& to_copy_) :
 			_left_top_right_bottom(_make_data(to_copy_.Left(), to_copy_.Top(), to_copy_.Right(), to_copy_.Bottom()))
 		{
 		}
@@ -125,9 +125,21 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_move_">Rect of a different type to move/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(EmuMath::Rect<ToCopyT_>&& to_move_) :
+		explicit constexpr inline Rect(EmuMath::Rect<ToCopyT_>&& to_move_) :
 			_left_top_right_bottom(_make_data(std::move(to_move_.Left()), std::move(to_move_.Top()), std::move(to_move_.Right()), std::move(to_move_.Bottom())))
 		{
+		}
+#pragma endregion
+
+#pragma region ASSIGNMENT_FUNCS
+	public:
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		constexpr inline void Set(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
+		{
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Left(), std::forward<Left_>(left_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Top(), std::forward<Top_>(top_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Right(), std::forward<Right_>(right_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Bottom(), std::forward<Bottom_>(bottom_));
 		}
 #pragma endregion
 
@@ -139,9 +151,37 @@ namespace EmuMath
 			return *this;
 		}
 
+		constexpr inline this_type& operator=(Rect<T_>& to_copy_)
+		{
+			_left_top_right_bottom = to_copy_._left_top_right_bottom;
+			return *this;
+		}
+
 		constexpr inline this_type& operator=(Rect<T_>&& to_move_) noexcept
 		{
 			_left_top_right_bottom = std::move(to_move_._left_top_right_bottom);
+			return *this;
+		}
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(const Rect<RhsT_>& rhs_)
+		{
+			Set(rhs_.Left(), rhs_.Top(), rhs_.Right(), rhs_.Bottom());
+			return *this;
+		}
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(Rect<RhsT_>& rhs_)
+		{
+			Set(rhs_.Left(), rhs_.Top(), rhs_.Right(), rhs_.Bottom());
+			return *this;
+		}
+
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(Rect<RhsT_>&& rhs_)
+		{
+			Set(std::move(rhs_.Left()), std::move(rhs_.Top()), std::move(rhs_.Right()), std::move(rhs_.Bottom()));
 			return *this;
 		}
 #pragma endregion

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -1,0 +1,510 @@
+#ifndef EMU_MATH_RECT_T_H_INC_
+#define EMU_MATH_RECT_T_H_INC_ 1
+
+#include "../../Vector.h"
+
+namespace EmuMath
+{
+	/// <summary>
+	/// <para> Type used to store and retrieve basic information regarding a rectangle, with the origin point (0, 0) at a theoretical top-left. </para>
+	/// </summary>
+	template<typename T_>
+	struct Rect
+	{
+	private:
+		using _underlying_vector = EmuMath::Vector<4, T_>;
+		static constexpr std::size_t _left_index = 0;
+		static constexpr std::size_t _top_index = 1;
+		static constexpr std::size_t _right_index = 2;
+		static constexpr std::size_t _bottom_index = 3;
+
+	public:
+		using this_type = Rect<T_>;
+		using stored_type = typename _underlying_vector::stored_type;
+		using value_type = typename _underlying_vector::value_type;
+		using value_type_uq = typename _underlying_vector::value_type_uq;
+		using preferred_floating_point = typename _underlying_vector::preferred_floating_point;
+
+		[[nodiscard]] static constexpr inline value_type_uq get_implied_zero()
+		{
+			return _underlying_vector::get_implied_zero();
+		}
+
+	private:
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
+		{
+			return _underlying_vector(std::forward<Left_>(left_), std::forward<Top_>(top_), std::forward<Right_>(right_), std::forward<Bottom_>(bottom_));
+		}
+
+		template<typename Width_, typename Height_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Width_&& width_, Height_&& height_)
+		{
+			return _underlying_vector(get_implied_zero(), get_implied_zero(), std::forward<Width_>(width_), std::forward<Height_>(height_));
+		}
+
+		template<typename Size_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Size_&& size_)
+		{
+			auto& size = EmuCore::TMP::lval_ref_cast<Size_>(std::forward<Size_>(size_));
+			return _underlying_vector(get_implied_zero(), get_implied_zero(), static_cast<value_type>(size), static_cast<value_type>(size));
+		}
+
+#pragma region CONSTRUCTORS
+	public:
+		constexpr inline Rect() : _left_top_right_bottom()
+		{
+		}
+
+		constexpr inline Rect(const Rect& to_copy_) :
+			_left_top_right_bottom(to_copy_._left_top_right_bottom)
+		{
+		}
+
+		constexpr inline Rect(Rect&& to_move_) noexcept : 
+			_left_top_right_bottom(std::move(to_move_._left_top_right_bottom))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect as a square of the specified size, with its top-left corner at point (0, 0). </para>
+		/// </summary>
+		/// <param name="size_">Size of the square to create the Rect as.</param>
+		template<typename Size_>
+		constexpr inline Rect(Size_&& size_) :
+			_left_top_right_bottom(_make_data(std::forward<Size_>(size_)))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect of the specified size, with its top-left corner at the point (0, 0). </para>
+		/// </summary>
+		/// <param name="width_">Size of the Rect in the X-axis.</param>
+		/// <param name="height_">Size of the Rect in the Y-axis.</param>
+		template<typename Width_, typename Height_>
+		constexpr inline Rect(Width_&& width_, Height_&& height_) : 
+			_left_top_right_bottom(_make_data(std::forward<Width_>(width_), std::forward<Height_>(height_)))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect with the axes of its borders defined by the respective passed values. </para>
+		/// </summary>
+		/// <param name="left_">X-coordinate of the Rect's left boundary. This should be the smallest value in the X-axis to be considered well-formed.</param>
+		/// <param name="top_">Y-coordinate of the Rect's top boundary. This should be the smallest value in the Y-axis to be considered well-formed.</param>
+		/// <param name="right_">X-coordinate of the Rect's right boundary. This should be the highest value in the X-axis to be considered well-formed.</param>
+		/// <param name="bottom_">Y-coordinate of the Rect's bottom boundary. This should be the highest value in the Y-axis to be considered well-formed.</param>
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		constexpr inline Rect(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_) :
+			_left_top_right_bottom(_make_data(std::forward<Left_>(left_), std::forward<Top_>(top_), std::forward<Right_>(right_), std::forward<Bottom_>(bottom_)))
+		{
+		}
+#pragma endregion
+
+#pragma region ASSIGNMENT_OPERATORS
+	public:
+		constexpr inline this_type& operator=(const Rect<T_>& to_copy_)
+		{
+			_left_top_right_bottom = to_copy_._left_top_right_bottom;
+			return *this;
+		}
+
+		constexpr inline this_type& operator=(Rect<T_>&& to_move_) noexcept
+		{
+			_left_top_right_bottom = std::move(to_move_._left_top_right_bottom);
+			return *this;
+		}
+#pragma endregion
+
+#pragma region ACCESSORS
+	private:
+		template<std::size_t Index_, std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
+		[[nodiscard]] constexpr inline decltype(auto) _get_item_for_vector()
+		{
+			if constexpr (Index_ == Left_)
+			{
+				return Left();
+			}
+			else if constexpr (Index_ == Top_)
+			{
+				return Top();
+			}
+			else if constexpr (Index_ == Right_)
+			{
+				return Right();
+			}
+			else if constexpr (Index_ == Bottom_)
+			{
+				return Bottom();
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<Left_>(),
+					"Failed to shuffle an EmuMath Rect into a 4D EmuMath Vector: At least one of the provided directional indices is invalid."
+				);
+			}
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
+		[[nodiscard]] static constexpr inline bool _valid_convert_to_vector_indices()
+		{
+			return
+			(
+				(Left_ != 0 && Top_ != 0 && Right_ != 0 && Bottom_ != 0) &&
+				(Left_ >= 0 && Left_ <= 3 && Top_ >= 0 && Top_ <= 3 && Right_ >= 0 && Right_ <= 3 && Bottom_ >= 0 && Bottom_ <= 3)
+			);
+		}
+
+	public:
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] static constexpr inline bool can_convert_to_vector()
+		{
+			return
+			(
+				_valid_convert_to_vector_indices<Left_, Top_, Right_, Bottom_>() &&
+				std::is_constructible_v<EmuMath::Vector<4, OutT_>, value_type&, value_type&, value_type&, value_type&>
+			);
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] static constexpr inline bool can_const_convert_to_vector()
+		{
+			return
+			(
+				_valid_convert_to_vector_indices<Left_, Top_, Right_, Bottom_>() &&
+				std::is_constructible_v<EmuMath::Vector<4, OutT_>, const value_type&, const value_type&, const value_type&, const value_type&>
+			);
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the X coordinate of left corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Left()
+		{
+			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Left() const
+		{
+			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the X coordinate of right corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Right()
+		{
+			return _left_top_right_bottom.template at<_right_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Right() const
+		{
+			return _left_top_right_bottom.template at<_right_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the Y coordinate of top corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Top()
+		{
+			return _left_top_right_bottom.template at<_top_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Top() const
+		{
+			return _left_top_right_bottom.template at<_top_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the Y coordinate of bottom corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Bottom()
+		{
+			return _left_top_right_bottom.template at<_bottom_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Bottom() const
+		{
+			return _left_top_right_bottom.template at<_bottom_index>();
+		}
+
+		/// <summary>
+		/// <para> Calculates the width of this Rectangle based on the distance between its left and right points. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width of this Rectangle, based on `Right - Left`.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ Width() const
+		{
+			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Right(), Left()));
+		}
+
+		/// <summary>
+		/// <para> Calculates the height of this Rectangle based on the distance between its top and bottom points. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width of this Rectangle, based on `Bottom - Top`.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ Height() const
+		{
+			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Bottom(), Top()));
+		}
+
+		/// <summary>
+		/// <para> Calculates the size of this Rectangle in both axes and outputs the results as a 2D Vector. </para>
+		/// <para> The width (X) will be stored in index 0; the height (Y) will be stored in index 1. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width and height of this Rectangle, based on `Right - Left` and `Bottom - Top` respectively.</returns>
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Size() const
+		{
+			return EmuMath::Vector<2, OutT_>(Width(), Height());
+		}
+
+		/// <summary>
+		/// <para> Calculates the squared length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The squared length of this Rectangle.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ DiagonalSquaredLength() const
+		{
+			return EmuMath::Helpers::vector_square_magnitude<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+		/// </summary>
+		/// <returns>The length of this Rectangle.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ DiagonalLengthConstexpr() const
+		{
+			return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>The length of this Rectangle.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ DiagonalLength() const
+		{
+			return EmuMath::Helpers::vector_magnitude<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle in the X-axis. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Width` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>Central point of this Rectangle in the X-axis.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ CentralX() const
+		{
+			return EmuCore::do_add<Out_, Out_>()
+			(
+				static_cast<Out_>(Left()),
+				EmuCore::do_divide<Out_, Out_>()(Width<Out_>(), Out_(2))
+			);
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle in the Y-axis. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Height` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>Central point of this Rectangle in the Y-axis.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ CentralY() const
+		{
+			return EmuCore::do_add<Out_, Out_>()
+			(
+				static_cast<Out_>(Top()),
+				EmuCore::do_divide<Out_, Out_>()(Height<Out_>(), Out_(2))
+			);
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle, and outputs the X- and Y-axes' points as indices 0 and 1 (respectively) of a 2D Vector. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Width` and `Height` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>2D EmuMath Vector containing this Rect's central X and Y points in indices 0 and 1 respectively.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Centre() const
+		{
+			return EmuMath::Vector<2, OutT_>(CentralX<OutT_>(), CentralY<OutT_>());
+		}
+
+		/// <summary>
+		/// <para> Outputs a 4D Vector containing this Rect's Left, Top, Right, and Bottom values in indices 0, 1, 2, and 3 respectively. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> This function supports output of references. </para>
+		/// </summary>
+		/// <returns>4D EmuMath Vector containing this Rect's Left, Top, Right, and Bottom values in indices 0, 1, 2, and 3 respectively.</returns>
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> AsVector()
+		{
+			return EmuMath::Vector<4, OutT_>(Left(), Top(), Right(), Bottom());
+		}
+
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> AsVector() const
+		{
+			return EmuMath::Vector<4, OutT_>(Left(), Top(), Right(), Bottom());
+		}
+
+		/// <summary>
+		/// <para> Outputs a 4D Vector containing this Rect's Left, Top, Right, and Bottom values in the respective specified indices. </para>
+		/// <para> The valid inclusive index range is 0:3, and the same index may not be repeated. Specified indices relate to the output Vector. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> This function supports output of references. </para>
+		/// </summary>
+		/// <returns>4D EmuMath Vector containing this Rect's Left, Top, Right, and Bottom values in the respective specified indices..</returns>
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline auto AsVector()
+			-> std::enable_if_t<can_convert_to_vector<Left_, Top_, Right_, Bottom_, OutT_>(), EmuMath::Vector<4, OutT_>>
+		{
+			return EmuMath::Vector<4, OutT_>
+			(
+				_get_item_for_vector<0, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<1, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<2, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<3, Left_, Top_, Right_, Bottom_>()
+			);
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline auto AsVector() const
+			-> std::enable_if_t<can_const_convert_to_vector<Left_, Top_, Right_, Bottom_, OutT_>(), EmuMath::Vector<4, OutT_>>
+		{
+			return EmuMath::Vector<4, OutT_>
+			(
+				_get_item_for_vector<0, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<1, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<2, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<3, Left_, Top_, Right_, Bottom_>()
+			);
+		}
+#pragma endregion
+
+#pragma region VALIDITY_CHECKS
+	public:
+		/// <summary>
+		/// <para> Checks if the current state of this Rect has a well-formed X axis. </para>
+		/// <para> A well-formed X-axis will have a Left value less than or equal to its Right value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's X-axis is well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormedX() const
+		{
+			return EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>()(Left(), Right());
+		}
+
+		/// <summary>
+		/// <para> Checks if the current state of this Rect has a well-formed Y axis. </para>
+		/// <para> A well-formed Y-axis will have a Top value less than or equal to its Bottom value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's Y-axis is well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormedY() const
+		{
+			return EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>()(Top(), Bottom());
+		}
+
+		/// <summary>
+		/// <para> Checks if the current state of this Rect is well-formed.</para>
+		/// <para> A well-formed Rect will have a Left value less than or equal to its Right value, and a Top value less than or equal to its Bottom value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's X- and Y-axes are both well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormed() const
+		{
+			return WellFormedX() && WellFormedY();
+		}
+#pragma endregion
+
+#pragma region MUTATIONS
+	public:
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
+		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x = static_cast<OutT_>(std::forward<X_>(x_));
+			OutT_ y = static_cast<OutT_>(std::forward<Y_>(y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(y, height_div_2)
+			);
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_vector_">
+		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+		/// </param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(const EmuMath::Vector<VecSize_, VecT_>& x_and_y_vector_) const
+		{
+			return MakeCentred(x_and_y_vector_.template AtTheoretical<0>(), x_and_y_vector_.template AtTheoretical<1>());
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
+		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
+			);
+		}
+#pragma endregion
+
+	private:
+		_underlying_vector _left_top_right_bottom;
+	};
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
@@ -1,0 +1,42 @@
+#ifndef EMU_MATH_RECT_TMP_H_IN_
+#define EMU_MATH_RECT_TMP_H_IN_ 1
+
+#include "../../../Vector.h"
+
+namespace EmuMath
+{
+	template<typename T_>
+	struct Rect;
+}
+
+namespace EmuMath::TMP
+{
+	template<typename T_>
+	struct is_emu_rect
+	{
+	private:
+		using _t_uq = typename EmuCore::TMP::remove_ref_cv<T_>::type;
+
+	public:
+		static constexpr bool value = std::conditional_t
+		<
+			std::is_same_v<T_, _t_uq>,
+			std::false_type,
+			is_emu_rect<_t_uq>
+		>::value;
+	};
+
+	template<typename T_>
+	struct is_emu_rect<Rect<T_>>
+	{
+		static constexpr bool value = true;
+	};
+
+	template<typename T_>
+	static constexpr bool is_emu_rect_v = is_emu_rect<T_>::value;
+
+	template<typename T_>
+	concept EmuRect = is_emu_rect_v<T_>;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
@@ -169,6 +169,9 @@ namespace EmuMath::TMP
 	template<class T_>
 	static constexpr bool is_emu_vector_v = is_emu_vector<T_>::value;
 
+	template<typename T_>
+	concept EmuVector = is_emu_vector_v<T_>;
+
 	template<std::size_t Index_, class T_>
 	struct emu_vector_theoretical_return
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -566,6 +566,12 @@ namespace EmuMath
 		{
 			return valid_args_for_variadic_constructor<0, Args_...>();
 		}
+
+		template<class...Args_>
+		[[nodiscard]] static constexpr inline bool is_variadic_constructor_explicit()
+		{
+			return sizeof...(Args_) != size || EmuCore::TMP::is_any_check<EmuMath::TMP::is_emu_vector, Args_...>::value;
+		}
 #pragma endregion
 
 #pragma region UNDERLYING_CONSTRUCTION_HELPERS
@@ -1075,11 +1081,11 @@ namespace EmuMath
 
 		template
 		<
-			class...ConstructionArgs_,
-			typename = std::enable_if_t<valid_args_for_variadic_constructor<0, ConstructionArgs_...>()>
+			class...Args_,
+			typename = std::enable_if_t<valid_args_for_variadic_constructor<0, Args_...>()>
 		>
-		explicit constexpr inline Vector(ConstructionArgs_&&...construction_args_) :
-			_data(_variadic_construct<0>(std::forward<ConstructionArgs_>(construction_args_)...))
+		explicit(is_variadic_constructor_explicit<Args_...>()) constexpr inline Vector(Args_&&...construction_args_) : 
+			_data(_variadic_construct<0>(std::forward<Args_>(construction_args_)...))
 		{
 		}
 #pragma region ACCESS

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -627,6 +627,12 @@ int main()
 	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
+	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
+	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+	auto yoiyoi = vec_from_init_list;
+	yoiyoi = { 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24 };
+
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -23,6 +23,11 @@
 // Fast Vector
 #include "EmuMath/FastVector.h"
 
+#include "EmuCore/ArithmeticHelpers/CommonAlgebra.h"
+
+constexpr auto test_dot = EmuCore::dot<float>(1, 2, 6, 3, 7, 10);
+constexpr auto test_dot_2 = EmuCore::dot(5, 7);
+
 template<typename T_, std::size_t Size_>
 inline std::ostream& operator<<(std::ostream& str_, const std::array<T_, Size_>& arr_)
 {
@@ -627,9 +632,11 @@ int main()
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
-	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+	constexpr auto vec_from_init_list = std::move(EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
 	auto yoiyoi = vec_from_init_list;
 
+	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);
+	constexpr auto mbmfgkbmlk = EmuMath::Helpers::rect_get_left(EmuMath::Rect<int>(1, 2, 3, 4));
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -646,6 +646,15 @@ int main()
 	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);
 	constexpr auto mbmfgkbmlk = EmuMath::Helpers::rect_get_left(EmuMath::Rect<int>(1, 2, 3, 4));
 
+	constexpr auto collide_a = EmuMath::Rect<float>(0, 0, 5, 5);
+	constexpr auto collide_b = EmuMath::Rect<double>(5, 5, 6, 6);
+	constexpr auto colliding_a = collide_a.CollidingAxisAligned<true>(collide_b);
+	constexpr auto colliding_b = collide_a.CollidingAxisAligned<false>(collide_b);
+	constexpr auto colliding_c = collide_a.CollidingAxisAligned(collide_b);
+	constexpr auto colliding_d = collide_a.CollidingAxisAligned(collide_b.Translate(-0.2, -0.5));
+	constexpr auto colliding_e = collide_a.CollidingAxisAligned(collide_b.Scale(2, 2));
+	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -12,6 +12,7 @@
 #include "EmuMath/Noise.h"
 #include "EmuMath/Quaternion.h"
 #include "EmuMath/Random.h"
+#include "EmuMath/Rect.h"
 #include "EmuMath/Vector.h"
 
 // Test harness execution
@@ -581,6 +582,15 @@ int main()
 		100.0
 	);
 	std::cout << perspective_mat << "\n" << perspective_mat.Flatten() << "\n";
+
+	constexpr auto rect = EmuMath::Rect<float>(5);
+	constexpr auto rect_centre = rect.Centre();
+	constexpr auto rect_b = EmuMath::Rect<double>(3, 4.2, 10, 10);
+	constexpr auto rect_b_centre = rect_b.Centre();
+	constexpr auto rect_well_formed = rect.WellFormed();
+	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
+	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
+	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(EmuMath::Vector<2, int>(3, 217));
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -604,6 +604,29 @@ int main()
 	constexpr auto reduce_scaled_width = reduce_scaled_rect.Width();
 	constexpr auto reduce_scaled_size = reduce_scaled_rect.Size();
 
+	constexpr auto to_reflect = EmuMath::Rect<float>(1.5, 3, 2, 4);
+	constexpr auto reflect_a = to_reflect.Reflect<0, 0>();
+	constexpr auto reflect_b = to_reflect.Reflect<-1, 0>();
+	constexpr auto reflect_c = to_reflect.Reflect<1, 0>();
+	constexpr auto reflect_d = to_reflect.Reflect<0, -1>();
+	constexpr auto reflect_e = to_reflect.Reflect<0, 1>();
+	constexpr auto reflect_f = to_reflect.Reflect<-1, -1>();
+	constexpr auto reflect_g = to_reflect.Reflect<-1, 1>();
+	constexpr auto reflect_h = to_reflect.Reflect<1, -1>();
+	constexpr auto reflect_i = to_reflect.Reflect<1, 1>();
+	constexpr auto reflect_j = to_reflect.Reflect<1, 1>().Reflect<-1, -1>();
+
+	constexpr auto reflect_alt_a = to_reflect.Reflect(0, 0);
+	constexpr auto reflect_alt_b = to_reflect.Reflect(-1, 0);
+	constexpr auto reflect_alt_c = to_reflect.Reflect(1, 0);
+	constexpr auto reflect_alt_d = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_e = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_f = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_g = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_h = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -591,6 +591,18 @@ int main()
 	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
 	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
 	constexpr auto central_contains_point_a_ = rect_made_central.ContainsPoint(4, 3);
+	constexpr auto rect_to_scale = EmuMath::Rect<float>(1, -2, 2.5, 4.17);
+	constexpr auto pre_scale_centre = rect_to_scale.Centre();
+	constexpr auto pre_scale_width = rect_to_scale.Width();
+	constexpr auto pre_scale_size = rect_to_scale.Size();
+	constexpr auto scaled_rect = rect_to_scale * 2;
+	constexpr auto scaled_centre = scaled_rect.Centre();
+	constexpr auto scaled_width = scaled_rect.Width();
+	constexpr auto scaled_size = scaled_rect.Size();
+	constexpr auto reduce_scaled_rect = rect_to_scale * 0.5;
+	constexpr auto reduce_scaled_centre = reduce_scaled_rect.Centre();
+	constexpr auto reduce_scaled_width = reduce_scaled_rect.Width();
+	constexpr auto reduce_scaled_size = reduce_scaled_rect.Size();
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -655,6 +655,8 @@ int main()
 	constexpr auto colliding_e = collide_a.CollidingAxisAligned(collide_b.Scale(2, 2));
 	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
 
+	auto ree = EmuMath::Rect<double>();
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -631,8 +631,16 @@ int main()
 	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
+	constexpr auto test_scale_rect_base = EmuMath::Rect<float>(1);
+	constexpr auto scaled_a = test_scale_rect_base.Scale(2);
+	constexpr auto scaled_b = test_scale_rect_base.ScaleAnchored<0, 0>(2, 2);
+	constexpr auto scaled_c = test_scale_rect_base.ScaleAnchored<1, 0>(2, 2);
+	constexpr auto scaled_d = test_scale_rect_base.ScaleAnchored<-1, 0>(2, 2);
+	constexpr auto scaled_e = test_scale_rect_base.ScaleAnchored<0, 1>(2, 2);
+	constexpr auto scaled_f = test_scale_rect_base.ScaleAnchored<1, -1>(2, 2);
+
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
-	constexpr auto vec_from_init_list = std::move(EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
+	constexpr auto vec_from_init_list = EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 	auto yoiyoi = vec_from_init_list;
 
 	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -322,7 +322,6 @@ int main()
 
 
 	std::cout << "ASSIGN_TRANSLATION TESTS\n";
-	using Mat4x4f32CM = EmuMath::Matrix<4, 4, float, true>;
 	EmuMath::Matrix<4, 4, float, true> translate_assign_matrix(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160);
 	std::cout << translate_assign_matrix << "\n\n";
 	translate_assign_matrix.AssignTranslation(5);
@@ -341,8 +340,8 @@ int main()
 	std::cout << "Constexpr:\n" << rot_0 << "\n\n:Runtime:\n" << EmuMath::Helpers::matrix_make_rotation_3d_z<true, float, false>(-33) << "\n\n";
 
 	std::cout << "ROTATION MEMBER TESTS\n";
-	auto member_rot_runtime = Mat4x4f32CM::make_rotation_3d_z<false>(33);
-	constexpr auto member_rot = Mat4x4f32CM::make_rotation_3d_z_constexpr<4, true, false>(33);
+	auto member_rot_runtime = EmuMath::Matrix<4, 4, float, true>::make_rotation_3d_z<false>(33);
+	constexpr auto member_rot = EmuMath::Matrix<4, 4, float, true>::make_rotation_3d_z_constexpr<4, true, false>(33);
 	std::cout << "runtime: " << (member_rot_runtime * point_to_rotate) << "\n";
 	std::cout << "constexpr: " << (member_rot * point_to_rotate) << "\n";
 
@@ -630,7 +629,6 @@ int main()
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
 	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 	auto yoiyoi = vec_from_init_list;
-	yoiyoi = { 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24 };
 
 
 	system("pause");

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -590,7 +590,7 @@ int main()
 	constexpr auto rect_well_formed = rect.WellFormed();
 	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
 	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
-	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(EmuMath::Vector<2, int>(3, 217));
+	constexpr auto central_contains_point_a_ = rect_made_central.ContainsPoint(4, 3);
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####


### PR DESCRIPTION
Adds `Rect<typename>` template that generalises manipulating flat, axis-aligned rectangular spaces, along with common checks.

- This is implemented as a square with origin point `(0, 0)` at the top left corner (of a screen, for example).
- The square itself is composed of 4 edge values: Left, Top, Right, Bottom. The common interface for batch values will always follow this order.
   - Data is not required to be stored in the same order as above, but is recommended when using default helper implementations due to cache order optimisations.
   - Choice of `Left, Top, Right, Bottom` was chosen instead of `X, Y, Width, Height` as it makes certain checks cheaper, such as collision checks where we can compare edges directly instead of appending sizes to a point.
   - We only store these types to minimise memory requirements as these are likely to be used for GUI implementations later down the line, so many are likely to be wanted at once
      - This does mean that `Width` and `Height` are slightly more expensive than a basic get as a subtraction needs to be performed, but this is minimal and likely not often needed.