### PR TITLE
MOVES TO C++20 STANDARD | Matrix update projection

### DIFF
--- a/EmuMath/EmuMath/EmuCore/ArithmeticHelpers/CommonAlgebra.h
+++ b/EmuMath/EmuMath/EmuCore/ArithmeticHelpers/CommonAlgebra.h
@@ -1,0 +1,88 @@
+#ifndef EMU_CORE_COMMON_ALGEBRA_H_INC_
+#define EMU_CORE_COMMON_ALGEBRA_H_INC_ 1
+
+#include "CommonMath.h"
+#include "CommonValues.h"
+#include "../Functors/Arithmetic.h"
+#include "../TMPHelpers/DescriptiveEnableIf.h"
+#include "../TMPHelpers/TypeObfuscation.h"
+
+namespace EmuCore
+{
+	/// <summary>
+	/// <para> Template function to calculate the dot product of any arbitrary number of values. </para>
+	/// <para> Only invoked when at least 3 arguments are passed. </para>
+	/// <para> Requires an output type as its first template argument. </para>
+	/// </summary>
+	/// <param name="values_">All values to be used in calculation of the dot product.</param>
+	/// <returns>The dot product of all passed `values_`.</returns>
+	template<typename Out_ = void, typename...Ts_, typename = EmuCore::TMP::enable_if_min_typeargs_t<3, Ts_...>>
+	[[nodiscard]] constexpr inline decltype(auto) dot(Ts_&&...values_)
+	{
+		if constexpr (std::is_void_v<Out_>)
+		{
+			return 
+			(
+				Out_(0) + 
+				... + 
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<Ts_>::type, typename EmuCore::TMP::remove_ref_cv<Ts_>::type>()
+				(
+					EmuCore::TMP::const_lval_ref_cast<Ts_>(values_),
+					EmuCore::TMP::const_lval_ref_cast<Ts_>(values_)
+				)
+			);
+		}
+		else
+		{
+			return static_cast<Out_>
+			(
+				(
+					Out_(0) + 
+					... + 
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<Ts_>::type, typename EmuCore::TMP::remove_ref_cv<Ts_>::type>()
+					(
+						EmuCore::TMP::const_lval_ref_cast<Ts_>(values_),
+						EmuCore::TMP::const_lval_ref_cast<Ts_>(values_)
+					)
+				)
+			);
+		}		
+	}
+
+	/// <summary>
+	/// <para> Template function to calculate the dot product of 2 passed values of arbitrary types. </para>
+	/// <para> This function may be specialised for special types which may produce dot products differently (such as mathematical vectors). </para>
+	/// <para> Requires an output type as its first template argument. </para>
+	/// </summary>
+	/// <param name="a_">First item for calculating the dot product.</param>
+	/// <param name="b_">Second item for calculating the dot product.</param>
+	/// <returns>Dot product of `a_` and `b_`, which is equivalent to `(a_ * a_) + (b_ * b_)` for scalar types.</returns>
+	template<typename Out_ = void, typename A_, typename B_>
+	[[nodiscard]] constexpr inline decltype(auto) dot(A_&& a_, B_&& b_)
+	{
+		const auto& a_lval = EmuCore::TMP::const_lval_ref_cast<A_>(std::forward<A_>(a_));
+		const auto& b_lval = EmuCore::TMP::const_lval_ref_cast<B_>(std::forward<B_>(b_));
+
+		if constexpr(std::is_void_v<Out_>)
+		{
+			return EmuCore::do_add<void, void>()
+			(
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<A_>::type, typename EmuCore::TMP::remove_ref_cv<A_>::type>()(a_lval, a_lval),
+				EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<B_>::type, typename EmuCore::TMP::remove_ref_cv<B_>::type>()(b_lval, b_lval)
+			);
+		}
+		else
+		{
+			return static_cast<Out_>
+			(
+				EmuCore::do_add<void, void>()
+				(
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<A_>::type, typename EmuCore::TMP::remove_ref_cv<A_>::type>()(a_lval, a_lval),
+					EmuCore::do_multiply<typename EmuCore::TMP::remove_ref_cv<B_>::type, typename EmuCore::TMP::remove_ref_cv<B_>::type>()(b_lval, b_lval)
+				)
+			);
+		}
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/DescriptiveEnableIf.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/DescriptiveEnableIf.h
@@ -1,0 +1,37 @@
+#ifndef EMU_CORE_TMP_DESCRIPTIVE_ENABLE_IF_H_INC_
+#define EMU_CORE_TMP_DESCRIPTIVE_ENABLE_IF_H_INC_ 1
+
+#include <functional>
+#include <type_traits>
+
+namespace EmuCore::TMP
+{
+	template<std::size_t Count_>
+	struct min_arg_count {};
+
+	template<std::size_t Count_>
+	struct max_arg_count {};
+
+	template<std::size_t Min_, std::size_t Max_>
+	struct min_max_arg_count {};
+
+	template<std::size_t Min_, class...T_>
+	using enable_if_min_typeargs_t = std::enable_if_t<(sizeof...(T_) >= Min_), min_arg_count<Min_>>;
+
+	template<std::size_t Max_, class...T_>
+	using enable_if_max_typeargs_t = std::enable_if_t<(sizeof...(T_) <= Max_), max_arg_count<Max_>>;
+
+	template<std::size_t Min_, std::size_t Max_, class...T_>
+	using enable_if_min_max_typeargs_t = std::enable_if_t<(sizeof...(T_) >= Min_ &&sizeof...(T_) <= Max_), min_max_arg_count<Min_, Max_>>;
+
+	template<std::size_t Min_, auto...Vals_>
+	using enable_if_min_val_args_t = std::enable_if_t<(sizeof...(Vals_) >= Min_), min_arg_count<Min_>>;
+
+	template<std::size_t Max_, auto...Vals_>
+	using enable_if_max_val_args_t = std::enable_if_t<(sizeof...(Vals_) <= Max_), max_arg_count<Max_>>;
+
+	template<std::size_t Min_, std::size_t Max_, auto...Vals_>
+	using enable_if_min_max_val_args_t = std::enable_if_t<(sizeof...(Vals_) >= Min_ && sizeof...(Vals_) <= Max_), min_max_arg_count<Min_, Max_>>;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/StdFeatureChecks.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/StdFeatureChecks.h
@@ -6,12 +6,27 @@
 namespace EmuCore::TMP
 {
 	/// <summary>
+	/// <para> Boolean indicating if the current C++ Standard supports concepts. </para>
+	/// </summary>
+	[[nodiscard]] constexpr inline bool feature_concepts()
+	{
+#ifdef __cpp_concepts
+		return true;
+#else
+		return false;
+#endif
+	}
+
+	/// <summary>
 	/// <para> Boolean indicating if the current C++ Standard supports constexpr dynamic memory allocation (such as constexpr std::string). </para>
-	/// <para> Under MSVC, will always be false without the /Zc:__cplusplus switch enabled, as of 2022/02/07. </para>
 	/// </summary>
 	[[nodiscard]] constexpr inline bool feature_constexpr_dynamic_memory()
 	{
-		return __cplusplus >= 201907L;
+#ifdef __cpp_constexpr_dynamic_alloc
+		return true;
+#else
+		return false;
+#endif
 	}
 }
 

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
@@ -324,7 +324,7 @@ namespace EmuCore::TMP
 	{
 		using type = typename Template_<Ts_...>::value_type;
 	};
-	template<template<std::size_t Size__, typename Ts__> class Template_, std::size_t Size_, typename...Ts_>
+	template<template<std::size_t InSize_, typename Ts__> class Template_, std::size_t Size_, typename...Ts_>
 	struct get_value_type<Template_<Size_, Ts_...>>
 	{
 		using type = typename Template_<Size_, Ts_...>::value_type;
@@ -334,12 +334,12 @@ namespace EmuCore::TMP
 	{
 		using type = typename Template_<SizeX_, SizeY_, Ts_...>::value_type;
 	};
-	template<template<typename T__, std::size_t Size__> class Template_, typename T_, std::size_t Size_>
+	template<template<typename U_, std::size_t InSize_> class Template_, typename T_, std::size_t Size_>
 	struct get_value_type<Template_<T_, Size_>>
 	{
 		using type = typename Template_<T_, Size_>::value_type;
 	};
-	template<template<typename T__, std::size_t SizeX__, std::size_t SizeY__> class Template_, typename T_, std::size_t SizeX_, std::size_t SizeY_>
+	template<template<typename U_, std::size_t SizeX__, std::size_t SizeY__> class Template_, typename T_, std::size_t SizeX_, std::size_t SizeY_>
 	struct get_value_type<Template_<T_, SizeX_, SizeY_>>
 	{
 		using type = typename Template_<T_, SizeX_, SizeY_>::value_type;

--- a/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
+++ b/EmuMath/EmuMath/EmuCore/TMPHelpers/TypeConvertors.h
@@ -442,6 +442,27 @@ namespace EmuCore::TMP
 		return static_cast<std::remove_reference_t<T_>&>(ref_);
 	}
 
+	/// <summary>
+	/// <para> Casts a reference to a const-qualified lvalue-reference. </para>
+	/// <para> This can effectively be considered an `unmove` cast, treating lvalues as lvalues and casting rvalues to lvalues. </para>
+	/// <para>
+	///		WARNING: This is for casting pre-existing, named rvalues.
+	///		Passing a new rvalue (such as `my_type(5)) will result in output of a dangling reference. 
+	/// </para>
+	/// </summary>
+	/// <param name="ref_">Reference to cast to an lvalue reference.</param>
+	/// <returns>The passed ref_ cast to a const-qualified lvalue reference.</returns>
+	template<typename T_>
+	[[nodiscard]] constexpr inline const std::remove_reference_t<T_>& const_lval_ref_cast(std::remove_reference_t<T_>& ref_)
+	{
+		return ref_;
+	}
+	template<typename T_>
+	[[nodiscard]] constexpr inline const std::remove_reference_t<T_>& const_lval_ref_cast(std::remove_reference_t<T_>&& ref_)
+	{
+		return static_cast<std::remove_reference_t<T_>&>(ref_);
+	}
+
 	/// <summary> Type used to alias type T_ as its internal type alias. Mainly for use in conditions such as `std::conditional_t&lt;bool, x, y&gt;::type`. </summary>
 	/// <typeparam name="T_">Type to be accessible by the defined type alias.</typeparam>
 	template<typename T_>

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_perspective.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_vector_extensions.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_all_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_common_quaternion_helper_includes.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_conversions\_quaternion_conversion_from_euler.h" />
@@ -315,6 +316,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_special_operations_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_stream_append_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_tmp.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_vector_operators.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_vector_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\__common\_common_math_tmp.h" />
     <ClInclude Include="EmuSIMD\SIMDHelpers.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -183,6 +183,8 @@
     <ClInclude Include="EmuCore\TMPHelpers\Values.h" />
     <ClInclude Include="EmuCore\TMPHelpers\VariadicHelpers.h" />
     <ClInclude Include="EmuMath\Colour.h" />
+    <ClInclude Include="EmuMath\Common3D.h" />
+    <ClInclude Include="EmuMath\Fast3D.h" />
     <ClInclude Include="EmuMath\FastNoise.h" />
     <ClInclude Include="EmuMath\FastVector.h" />
     <ClInclude Include="EmuMath\Matrix.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="EmuCore\TMPHelpers\TypeObfuscation.h" />
     <ClInclude Include="EmuCore\TMPHelpers\Values.h" />
     <ClInclude Include="EmuCore\TMPHelpers\VariadicHelpers.h" />
+    <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h" />
     <ClInclude Include="EmuMath\Colour.h" />
     <ClInclude Include="EmuMath\Common3D.h" />
     <ClInclude Include="EmuMath\Fast3D.h" />
@@ -277,6 +278,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -277,8 +277,10 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_conversions.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_checks.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -197,6 +197,7 @@
     <ClInclude Include="EmuMath\Rect.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_fast_vectors\_fast_vector_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_projections.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_orthos_vulkan.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -190,6 +190,10 @@
     <ClInclude Include="EmuMath\Quaternion.h" />
     <ClInclude Include="EmuMath\Random.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_fast_vectors\_fast_vector_t.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_projections.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_perspective.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_all_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_common_quaternion_helper_includes.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_conversions\_quaternion_conversion_from_euler.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -189,10 +189,12 @@
     <ClInclude Include="EmuMath\Noise.h" />
     <ClInclude Include="EmuMath\Quaternion.h" />
     <ClInclude Include="EmuMath\Random.h" />
+    <ClInclude Include="EmuMath\Rect.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_fast_vectors\_fast_vector_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_projections.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_perspective.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_all_helpers.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_helpers\_common_quaternion_helper_includes.h" />
@@ -268,6 +270,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_std_ops\_vector_do_swap_specialisation.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_common_vector_helpers.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -119,7 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>Default</LanguageStandard_C>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -171,7 +171,7 @@
     <ClInclude Include="EmuCore\Functors\StdOps.h" />
     <ClInclude Include="EmuCore\TestingHelpers\LoopingTestHarness.h" />
     <ClInclude Include="EmuCore\TMPHelpers\DefaultItemBases.h" />
-    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h" />
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h" />
     <ClInclude Include="EmuCore\TMPHelpers\OperatorChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\SafeEnumFuncs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\StdAliases.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -152,6 +152,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EmuCore\ArithmeticHelpers\BitHelpers.h" />
+    <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h" />
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonMath.h" />
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonValues.h" />
     <ClInclude Include="EmuCore\CommonTypes\ComparisonEnum.h" />
@@ -170,6 +171,7 @@
     <ClInclude Include="EmuCore\Functors\StdOps.h" />
     <ClInclude Include="EmuCore\TestingHelpers\LoopingTestHarness.h" />
     <ClInclude Include="EmuCore\TMPHelpers\DefaultItemBases.h" />
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\OperatorChecks.h" />
     <ClInclude Include="EmuCore\TMPHelpers\SafeEnumFuncs.h" />
     <ClInclude Include="EmuCore\TMPHelpers\StdAliases.h" />
@@ -272,7 +274,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_arithmetic.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_quaternions\_underlying_helpers\_quaternion_underlying_get.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_all_core_functor_specialisations.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_core_functor_specialisations\_std_ops\_vector_do_swap_specialisation.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_helpers\_common_vector_helpers.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj
+++ b/EmuMath/EmuMath/EmuMath.vcxproj
@@ -316,6 +316,7 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_stream_append_underlying.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_underlying_helpers\_vector_tmp.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_vector_t.h" />
+    <ClInclude Include="EmuMath\_do_not_manually_include\__common\_common_math_tmp.h" />
     <ClInclude Include="EmuSIMD\SIMDHelpers.h" />
     <ClInclude Include="EmuMath\Vector.h" />
     <ClInclude Include="EmuMath\_do_not_manually_include\_colours\_colour_arithmetic_functors.h" />

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -866,5 +866,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_orthos_vulkan.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\__common\_common_math_tmp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -818,5 +818,14 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_ortho.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\Rect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -833,5 +833,23 @@
     <ClInclude Include="EmuMath\Fast3D.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_underlying_helpers\_rect_tmp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_get.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_common_rect_helper_includes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_all_rect_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -857,5 +857,11 @@
     <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_checks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_conversions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -806,5 +806,17 @@
     <ClInclude Include="EmuCore\TMPHelpers\DefaultItemBases.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_underlying_projections\_matrix_underlying_perspective.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_underlying_helpers\_matrix_underlying_projections.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_matrix_projections.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_perspectives_vulkan.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -869,5 +869,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\__common\_common_math_tmp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_vector_extensions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_vectors\_vector_operators.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -848,7 +848,7 @@
     <ClInclude Include="EmuCore\ArithmeticHelpers\CommonAlgebra.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIfTypeargs.h">
+    <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -827,5 +827,11 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_rect_t.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\Common3D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\Fast3D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -863,5 +863,8 @@
     <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_conversions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_matrix\_helpers\_projections\_vulkan\_matrix_orthos_vulkan.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath.vcxproj.filters
+++ b/EmuMath/EmuMath/EmuMath.vcxproj.filters
@@ -851,5 +851,11 @@
     <ClInclude Include="EmuCore\TMPHelpers\DescriptiveEnableIf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EmuMath\_do_not_manually_include\_rect\_helpers\_rect_mutate.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EmuMath\BringHelpersToEmuMathNamespace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/EmuMath/EmuMath/EmuMath/BringHelpersToEmuMathNamespace.h
+++ b/EmuMath/EmuMath/EmuMath/BringHelpersToEmuMathNamespace.h
@@ -1,0 +1,10 @@
+#ifndef EMU_MATH_BRING_HELPERS_TO_EMU_MATH_NAMESPACE_H_INC
+#define EMU_MATH_BRING_HELPERS_TO_EMU_MATH_NAMESPACE_H_INC 1
+
+namespace EmuMath
+{
+	namespace Helpers {}
+	using namespace EmuMath::Helpers;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Common3D.h
+++ b/EmuMath/EmuMath/EmuMath/Common3D.h
@@ -1,0 +1,9 @@
+#ifndef EMU_MATH_COMMON_3D_H_INC_
+#define EMU_MATH_COMMON_3D_H_INC_ 1
+
+#include "Matrix.h"
+#include "Quaternion.h"
+#include "Rect.h"
+#include "Vector.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Fast3D.h
+++ b/EmuMath/EmuMath/EmuMath/Fast3D.h
@@ -1,0 +1,7 @@
+#ifndef EMU_MATH_FAST_3D_H_INC_
+#define EMU_MATH_FAST_3D_H_INC_ 1
+
+#include "Common3D.h"
+#include "FastVector.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Matrix.h
+++ b/EmuMath/EmuMath/EmuMath/Matrix.h
@@ -3,5 +3,6 @@
 
 #include "_do_not_manually_include/_matrix/_matrix_t.h"
 #include "_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h"
+#include "_do_not_manually_include/_matrix/_vector_extensions.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/Rect.h
+++ b/EmuMath/EmuMath/EmuMath/Rect.h
@@ -1,0 +1,6 @@
+#ifndef EMU_MATH_RECT_H_INC_
+#define EMU_MATH_RECT_H_INC_ 1
+
+#include "_do_not_manually_include/_rect/_rect_t.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/Vector.h
+++ b/EmuMath/EmuMath/EmuMath/Vector.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_VECTOR_H_INC_ 1
 
 #include "_do_not_manually_include/_vectors/_vector_t.h"
+#include "_do_not_manually_include/_vectors/_vector_operators.h"
 #include "_do_not_manually_include/_vectors/_core_functor_specialisations/_all_core_functor_specialisations.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/__common/_common_math_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/__common/_common_math_tmp.h
@@ -1,0 +1,119 @@
+#ifndef EMU_MATH_COMMON_MATH_TMP_H_INC_
+#define EMU_MATH_COMMON_MATH_TMP_H_INC_ 1
+
+#include "../../../EmuCore/TMPHelpers/TypeConvertors.h"
+
+namespace EmuMath::TMP
+{
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Colour. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Colour, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_colour : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_colour, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_colour_v = is_emu_colour<T_>::value;
+
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Fast Vector. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Fast Vector, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_fast_vector : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_fast_vector, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_fast_vector_v = is_emu_fast_vector<T_>::value;
+
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Matrix. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Matrix, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_matrix : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_matrix, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_matrix_v = is_emu_matrix<T_>::value;
+
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Quaternion. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Quaternion, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_quaternion : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_quaternion, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_quaternion_v = is_emu_quaternion<T_>::value;
+
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Rect. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Rect, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_rect : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_rect, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_rect_v = is_emu_rect<T_>::value;
+
+	/// <summary>
+	/// <para> Type to determine if the passed T_ is a type of EmuMath Vector. </para>
+	/// <para> The value will also be true if T_ is a reference to an EmuMath Vector, and ignores const/ref qualifiers. Pointers remain false. </para>
+	/// </summary>
+	template<class T_>
+	struct is_emu_vector : public EmuCore::TMP::type_check_ignore_ref_cv_base<is_emu_vector, std::false_type, T_>
+	{
+	};
+	template<class T_>
+	static constexpr bool is_emu_vector_v = is_emu_vector<T_>::value;
+}
+
+namespace EmuMath::Concepts
+{
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Colour. Effectively a check that `is_emu_colour::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuColour = EmuMath::TMP::is_emu_colour_v<T_>;
+
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Fast Vector. Effectively a check that `is_emu_fast_vector::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuFastVector = EmuMath::TMP::is_emu_fast_vector_v<T_>;
+
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Matrix. Effectively a check that `is_emu_matrix::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuMatrix = EmuMath::TMP::is_emu_matrix_v<T_>;
+
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Quaternion. Effectively a check that `is_emu_quaternion::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuQuaternion = EmuMath::TMP::is_emu_quaternion_v<T_>;
+
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Rect. Effectively a check that `is_emu_rect::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuRect = EmuMath::TMP::is_emu_rect_v<T_>;
+
+	/// <summary>
+	/// <para> Concept that determines if the passed type T_ is an EmuMath Vector. Effectively a check that `is_emu_vector::value` is true. </para>
+	/// </summary>
+	template<class T_>
+	concept EmuVector = EmuMath::TMP::is_emu_vector_v<T_>;
+}
+
+namespace EmuConcepts
+{
+	using namespace EmuMath::Concepts;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/__common/_common_math_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/__common/_common_math_tmp.h
@@ -3,6 +3,7 @@
 
 #include "../../../EmuCore/TMPHelpers/TypeConvertors.h"
 
+#pragma region CHECKS
 namespace EmuMath::TMP
 {
 	/// <summary>
@@ -71,7 +72,9 @@ namespace EmuMath::TMP
 	template<class T_>
 	static constexpr bool is_emu_vector_v = is_emu_vector<T_>::value;
 }
+#pragma endregion
 
+#pragma region CONCEPTS
 namespace EmuMath::Concepts
 {
 	/// <summary>
@@ -115,5 +118,6 @@ namespace EmuConcepts
 {
 	using namespace EmuMath::Concepts;
 }
+#pragma endregion
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_colours/_helpers_underlying/_colour_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_colours/_helpers_underlying/_colour_tmp.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_COLOUR_TMP_H_INC_
 #define EMU_MATH_COLOUR_TMP_H_INC_ 1
 
+#include "../../__common/_common_math_tmp.h"
 #include "../../../../EmuCore/TMPHelpers/TypeConvertors.h"
 #include <type_traits>
 
@@ -12,24 +13,11 @@ namespace EmuMath
 
 namespace EmuMath::TMP
 {
-	template<class T_>
-	struct is_emu_colour
-	{
-		static constexpr bool value = std::conditional_t
-		<
-			// This is a recursive check to make sure that T_ does not have modifiers that may lead to false negatives
-			std::is_same_v<T_, typename EmuCore::TMP::remove_ref_cv<T_>::type>,
-			std::false_type,
-			is_emu_colour<typename EmuCore::TMP::remove_ref_cv<T_>::type>
-		>::value;
-	};
 	template<typename T_, bool ContainsAlpha_>
 	struct is_emu_colour<EmuMath::Colour<T_, ContainsAlpha_>>
 	{
 		static constexpr bool value = true;
-	};
-	template<class T_>
-	static constexpr bool is_emu_colour_v = is_emu_colour<T_>::value;
+	};;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_fast_vectors/_underlying_helpers/_fast_vector_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_fast_vectors/_underlying_helpers/_fast_vector_tmp.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_FAST_VECTOR_TMP_H_INC_
 #define EMU_MATH_FAST_VECTOR_TMP_H_INC_ 1
 
+#include "../../__common/_common_math_tmp.h"
 #include "../../../../EmuCore/TMPHelpers/TypeConvertors.h"
 #include <functional>
 #include <type_traits>
@@ -13,17 +14,6 @@ namespace EmuMath
 
 namespace EmuMath::TMP
 {
-	template<class T_>
-	struct is_emu_fast_vector
-	{
-		static constexpr bool value = std::conditional_t
-		<
-			std::is_same_v<T_, EmuCore::TMP::remove_ref_cv_t<T_>>,
-			std::false_type,
-			is_emu_fast_vector<EmuCore::TMP::remove_ref_cv_t<T_>>
-		>::value;
-	};
-
 	template<std::size_t Size_, typename T_, std::size_t RegisterWidth_>
 	struct is_emu_fast_vector<EmuMath::FastVector<Size_, T_, RegisterWidth_>>
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_all_matrix_helpers.h
@@ -8,6 +8,7 @@
 #include "_matrix_get.h"
 #include "_matrix_misc_arithmetic.h"
 #include "_matrix_mutate.h"
+#include "_matrix_projections.h"
 #include "_matrix_special_operations.h"
 #include "_matrix_std_multiply.h"
 #include "_matrix_stream_append.h"

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_common_matrix_helper_includes.h
@@ -7,6 +7,7 @@
 #include "../_underlying_helpers/_matrix_underlying_get.h"
 #include "../_underlying_helpers/_matrix_underlying_misc_arithmetic.h"
 #include "../_underlying_helpers/_matrix_underlying_mutate.h"
+#include "../_underlying_helpers/_matrix_underlying_projections.h"
 #include "../_underlying_helpers/_matrix_special_arithmetic.h"
 #include "../_underlying_helpers/_matrix_underlying_special_operations.h"
 #include "../_underlying_helpers/_matrix_underlying_stream_append.h"

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_arithmetic_assign.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_arithmetic_assign.h
@@ -426,6 +426,22 @@ namespace EmuMath::Helpers
 	}
 
 	/// <summary>
+	/// <para> Interprets the left-hand Vector as a Matrix with a single row of the Vector's size and multiplies it with the right-hand Matrix. </para>
+	/// <para> The left-hand Vector must have a size equal to the Matrix's number of columns (or its columns - 1, where the missing index is an implicit 1). </para>
+	/// </summary>
+	/// <param name="lhs_vector_">EmuMath Vector to interpret as a Row Matrix on the left-hand side of multiplication.</param>
+	/// <param name="rhs_matrix_">EmuMath Matrix appearing on the right-hand side of multiplication.</param>
+	template<EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	[[nodiscard]] constexpr inline void matrix_multiply_assign
+	(
+		EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		Matrix_&& rhs_matrix_
+	)
+	{
+		_matrix_underlying::_matrix_std_multiply_assign_vector_mat(lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
+	}
+
+	/// <summary>
 	/// <para> Performs a multiply-assign operation (e.g. operator*=) between the passed EmuMath Matrix and EmuMath Vector. </para>
 	/// <para> Unlike most arithmetic-assign operations, this will assign to the right-hand operand, as the result will be a Vector of equal size instead of a Matrix. </para>
 	/// <para> If needed, a copy of the provided Vector will be formed automatically to prevent invalid results developing from its assignment. </para>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_arithmetic_assign.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_arithmetic_assign.h
@@ -431,7 +431,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="lhs_vector_">EmuMath Vector to interpret as a Row Matrix on the left-hand side of multiplication.</param>
 	/// <param name="rhs_matrix_">EmuMath Matrix appearing on the right-hand side of multiplication.</param>
-	template<EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	template<EmuConcepts::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
 	[[nodiscard]] constexpr inline void matrix_multiply_assign
 	(
 		EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_projections.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_projections.h
@@ -1,0 +1,7 @@
+#ifndef EMU_MATH_MATRIX_PROJECTIONS_H_INC_
+#define EMU_MATH_MATRIX_PROJECTIONS_H_INC_ 1
+
+#include "_common_matrix_helper_includes.h"
+#include "_projections/_vulkan/_matrix_perspectives_vulkan.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_projections.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_projections.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_MATRIX_PROJECTIONS_H_INC_ 1
 
 #include "_common_matrix_helper_includes.h"
+#include "_projections/_vulkan/_matrix_orthos_vulkan.h"
 #include "_projections/_vulkan/_matrix_perspectives_vulkan.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_std_multiply.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_std_multiply.h
@@ -124,6 +124,26 @@ namespace EmuMath::Helpers
 	}
 #pragma endregion
 
+#pragma region MULTIPLY_WITH_VECTOR_LHS
+	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	[[nodiscard]] constexpr inline auto matrix_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
+		-> EmuMath::Vector<LhsSize_, OutT_>
+	{
+		return _matrix_underlying::_matrix_std_multiply_vector_mat<OutT_>(lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
+	}
+
+	template<std::size_t OutSize_, typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	[[nodiscard]] constexpr inline void matrix_multiply
+	(
+		EmuMath::Vector<OutSize_, OutT_>& out_vector_,
+		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		Matrix_&& rhs_matrix_
+	)
+	{
+		_matrix_underlying::_matrix_std_multiply_assign_vector_mat(out_vector_, lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
+	}
+#pragma endregion
+
 #pragma region MULTIPLY_WITH_VECTOR_RHS
 	/// <summary>
 	/// <para> Outputs an EmuMath Vector resulting from a multiplication with the provided Matrix. The Vector will be treated as a single-column Matrix. </para>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_std_multiply.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_matrix_std_multiply.h
@@ -125,14 +125,23 @@ namespace EmuMath::Helpers
 #pragma endregion
 
 #pragma region MULTIPLY_WITH_VECTOR_LHS
-	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	/// <summary>
+	/// <para> Outputs an EmuMath Vector resulting from a multiplication with the provided Matrix. The Vector will be treated as a single-row Matrix. </para>
+	/// <para> The Vector must meet constraint A or B: </para>
+	/// <para> A: The Vector's size is equal to the number of columns in the provided Matrix. </para>
+	/// <para> B: The Vector's size is equal to the number of columns in the provided Matrix - 1. In this case, the non-contained index will be treated as 1. </para>
+	/// </summary>
+	/// <param name="lhs_vector_">EmuMath Vector to interpret as a Row Matrix on the left-hand side of multiplication.</param>
+	/// <param name="rhs_matrix_">EmuMath Matrix appearing on the right-hand side of multiplication.</param>
+	/// <returns>EmuMath Vector resulting from a multiplication of the provided Vector and Matrix.</returns>
+	template<typename OutT_, EmuConcepts::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
 	[[nodiscard]] constexpr inline auto matrix_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
 		-> EmuMath::Vector<LhsSize_, OutT_>
 	{
 		return _matrix_underlying::_matrix_std_multiply_vector_mat<OutT_>(lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
 	}
 
-	template<std::size_t OutSize_, typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	template<std::size_t OutSize_, typename OutT_, EmuConcepts::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
 	[[nodiscard]] constexpr inline void matrix_multiply
 	(
 		EmuMath::Vector<OutSize_, OutT_>& out_vector_,

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_orthos_vulkan.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_orthos_vulkan.h
@@ -1,0 +1,90 @@
+#ifndef EMU_MATH_MATRIX_PROJECTIONS_ORTHO_VK_H_INC_
+#define EMU_MATH_MATRIX_PROJECTIONS_ORTHO_VK_H_INC_ 1
+
+#include "../../_common_matrix_helper_includes.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Creates an orthographic projection Matrix designed for use with Vulkan. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// </summary>
+	/// <param name="left_">Scalar left edge of the view perimiter.</param>
+	/// <param name="top_">Scalar top edge of the view perimiter.</param>
+	/// <param name="right_">Scalar right edge of the view perimiter.</param>
+	/// <param name="bottom_">Scalar bottom edge of the view perimiter</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>Orthographic Projection Matrix of the specified type intended for use with Vulkan.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_ortho_vk(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_ortho_vk<EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>>
+		(
+			std::forward<Left_>(left_),
+			std::forward<Top_>(top_),
+			std::forward<Right_>(right_),
+			std::forward<Bottom_>(bottom_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_)
+		);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_ortho_vk(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_ortho_vk<EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>>
+		(
+			std::forward<Left_>(left_),
+			std::forward<Top_>(top_),
+			std::forward<Right_>(right_),
+			std::forward<Bottom_>(bottom_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_)
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates an orthographic projection Matrix designed for use with Vulkan. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// </summary>
+	/// <param name="view_rect_">EmuMath Rect providing the Left, Top, Right, and Bottom edges of the view perimiter.</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>Orthographic Projection Matrix of the specified type intended for use with Vulkan.</returns>
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_ortho_vk<EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>>
+		(
+			std::forward<ViewRect_>(view_rect_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_)
+		);
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_ortho_vk<EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>>
+		(
+			std::forward<ViewRect_>(view_rect_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_)
+		);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_orthos_vulkan.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_orthos_vulkan.h
@@ -61,7 +61,7 @@ namespace EmuMath::Helpers
 	template
 	<
 		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
-		EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_
+		EmuConcepts::EmuRect ViewRect_, typename Near_, typename Far_
 	>
 	[[nodiscard]] constexpr inline auto matrix_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
 		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
@@ -74,7 +74,7 @@ namespace EmuMath::Helpers
 		);
 	}
 
-	template<typename OutT_, bool OutColumnMajor_ = true, EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_>
+	template<typename OutT_, bool OutColumnMajor_ = true, EmuConcepts::EmuRect ViewRect_, typename Near_, typename Far_>
 	[[nodiscard]] constexpr inline auto matrix_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
 		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_perspectives_vulkan.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_perspectives_vulkan.h
@@ -1,0 +1,152 @@
+#ifndef EMU_MATH_MATRIX_PROJECTIONS_PERSPECTIVE_VK_H_INC_
+#define EMU_MATH_MATRIX_PROJECTIONS_PERSPECTIVE_VK_H_INC_ 1
+
+#include "../../_common_matrix_helper_includes.h"
+
+namespace EmuMath::Helpers
+{
+#pragma region REVERSE_DEPTH
+	/// <summary>
+	/// <para> Creates a perspective Matrix designed for use with Vulkan and a reverse Z-buffer. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// <para> 
+	///		Input FOV angles may be interpreted as either radians or degrees, based on `FovIsRads_`, where `true` = radians, `false` = degrees. 
+	///		This may be omitted, in which case it defaults to `true`. 
+	/// </para>
+	/// </summary>
+	/// <param name="fov_y_">Scalar Y-axis FOV angle for the projection view.</param>
+	/// <param name="aspect_ratio_">Scalar aspect ratio of the projection view target.</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>EmuMath Matrix of the specified type containing a perspective projection Matrix for Vulkan with a reverse Z-buffer.</returns>
+	template
+	<
+		bool FovIsRads_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			true,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+		
+	template<bool FovIsRads_, typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			true,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+#pragma endregion
+
+#pragma region REVERSE_DEPTH_CONSTEXPR
+	/// <summary>
+	/// <para> Creates a perspective Matrix designed for use with Vulkan and a reverse Z-buffer. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// <para> 
+	///		Input FOV angles may be interpreted as either radians or degrees, based on `FovIsRads_`, where `true` = radians, `false` = degrees. 
+	///		This may be omitted, in which case it defaults to `true`. 
+	/// </para>
+	/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+	/// </summary>
+	/// <param name="fov_y_">Scalar Y-axis FOV angle for the projection view.</param>
+	/// <param name="aspect_ratio_">Scalar aspect ratio of the projection view target.</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>EmuMath Matrix of the specified type containing a perspective projection Matrix for Vulkan with a reverse Z-buffer.</returns>
+	template
+	<
+		bool FovIsRads_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			true,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+		
+	template<bool FovIsRads_, typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_reverse_depth_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk_reverse_depth
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			true,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_perspectives_vulkan.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_helpers/_projections/_vulkan/_matrix_perspectives_vulkan.h
@@ -5,6 +5,150 @@
 
 namespace EmuMath::Helpers
 {
+#pragma region SIMPLE
+	/// <summary>
+	/// <para> Creates a perspective Matrix designed for use with Vulkan. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// <para> 
+	///		Input FOV angles may be interpreted as either radians or degrees, based on `FovIsRads_`, where `true` = radians, `false` = degrees. 
+	///		This may be omitted, in which case it defaults to `true`. 
+	/// </para>
+	/// </summary>
+	/// <param name="fov_y_">Scalar Y-axis FOV angle for the projection view.</param>
+	/// <param name="aspect_ratio_">Scalar aspect ratio of the projection view target.</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>EmuMath Matrix of the specified type containing a perspective projection Matrix for Vulkan.</returns>
+	template
+	<
+		bool FovIsRads_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			true,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+		
+	template<bool FovIsRads_, typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			true,
+			false
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+#pragma endregion
+
+#pragma region SIMPLE_CONSTEXPR
+	/// <summary>
+	/// <para> Creates a perspective Matrix designed for use with Vulkan. </para>
+	/// <para> The size of the output Matrix may be omitted, in which case it will default to 4x4. </para>
+	/// <para> 
+	///		Input FOV angles may be interpreted as either radians or degrees, based on `FovIsRads_`, where `true` = radians, `false` = degrees. 
+	///		This may be omitted, in which case it defaults to `true`. 
+	/// </para>
+	/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+	/// </summary>
+	/// <param name="fov_y_">Scalar Y-axis FOV angle for the projection view.</param>
+	/// <param name="aspect_ratio_">Scalar aspect ratio of the projection view target.</param>
+	/// <param name="near_">Scalar boundary of the near clipping plane.</param>
+	/// <param name="far_">Scalar boundary of the far clapping plane.</param>
+	/// <returns>EmuMath Matrix of the specified type containing a perspective projection Matrix for Vulkan.</returns>
+	template
+	<
+		bool FovIsRads_, std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template
+	<
+		std::size_t OutNumColumns_, std::size_t OutNumRows_, typename OutT_, bool OutColumnMajor_ = true,
+		typename FovY_, typename AspectRatio_, typename Near_, typename Far_
+	>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<OutNumColumns_, OutNumRows_, OutT_, OutColumnMajor_>,
+			true,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+		
+	template<bool FovIsRads_, typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			FovIsRads_,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+
+	template<typename OutT_, bool OutColumnMajor_ = true, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline auto matrix_perspective_vk_constexpr(FovY_&& fov_y_, AspectRatio_&& aspect_ratio_, Near_&& near_, Far_&& far_)
+		-> EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>
+	{
+		return _matrix_underlying::_make_perspective_matrix_vk
+		<
+			EmuMath::Matrix<4, 4, OutT_, OutColumnMajor_>,
+			true,
+			true
+		>(std::forward<FovY_>(fov_y_), std::forward<AspectRatio_>(aspect_ratio_), std::forward<Near_>(near_), std::forward<Far_>(far_));
+	}
+#pragma endregion
+
+
 #pragma region REVERSE_DEPTH
 	/// <summary>
 	/// <para> Creates a perspective Matrix designed for use with Vulkan and a reverse Z-buffer. </para>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -16,6 +16,13 @@ namespace EmuMath
 	///		This common interface is nulled when using the Matrix via STL iterators or flattened indices (i.e. only a single, scalar index argument), 
 	///		in which case the specified contiguous storage order will be used.
 	/// </para>
+	/// <para>
+	///		--- NOTATION: Where cx = column x, rx = row x, columns and rows are referred to as the following for this Matrix type:
+	///		<para> --- | c0r0, c1r0, ..., cNumColumns_r0					  </para>
+	///		<para> --- | c0r1, c1r1, ..., cNumColumns_r1					  </para>
+	///		<para> --- | ...												  </para>
+	///		<para> --- | c0rNumRows_, c1rNumRows_, ..., cNumColumns_rNumRows_ </para>
+	/// </para>
 	/// </summary>
 	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
 	struct Matrix

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_matrix_t.h
@@ -6,12 +6,17 @@
 #include <tuple>
 #include <utility>
 
-// MISC MATH TO DO:
-// --- CLAMPS
-// --- That's literally it, I missed just one bloody thing
-
 namespace EmuMath
 {
+	/// <summary>
+	/// <para> Template that may be instantiated to create an arbitrarily sized Matrix type with data stored contiguously. </para>
+	/// <para> May specify if contiguous data is stored in column-major or row-major order. By default, column-major storage is used. </para>
+	/// <para>
+	///		Provides a column-major common interface and implementation, regardless of the ColumnMajor_ argument. 
+	///		This common interface is nulled when using the Matrix via STL iterators or flattened indices (i.e. only a single, scalar index argument), 
+	///		in which case the specified contiguous storage order will be used.
+	/// </para>
+	/// </summary>
 	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
 	struct Matrix
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_special_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_special_arithmetic.h
@@ -337,7 +337,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		);
 	}
 
-	template<std::size_t Index_, EmuMath::TMP::EmuVector OutVector_, EmuMath::TMP::EmuVector LhsVector_, EmuMath::TMP::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
+	template<std::size_t Index_, EmuConcepts::EmuVector OutVector_, EmuConcepts::EmuVector LhsVector_, EmuConcepts::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
 	[[nodiscard]] constexpr inline typename decltype(auto) _matrix_std_multiply_vector_mat_dp_for_index
 	(
 		const LhsVector_& lhs_vector_,
@@ -350,7 +350,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		);
 	}
 
-	template<std::size_t Index_, EmuMath::TMP::EmuVector LhsVector_, EmuMath::TMP::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
+	template<std::size_t Index_, EmuConcepts::EmuVector LhsVector_, EmuConcepts::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
 	[[nodiscard]] constexpr inline decltype(auto) _matrix_std_multiply_vector_mat_dp_for_assigned_index
 	(
 		const LhsVector_& lhs_vector_,
@@ -430,7 +430,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		return _matrix_std_multiply_mat_vector<EmuMath::Vector<RhsSize_, OutT_>>(out_indices(), dp_indices(), lhs_matrix_, rhs_vector_);
 	}
 
-	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_, std::size_t...OutIndices_, std::size_t...DpIndices_>
+	template<typename OutT_, EmuConcepts::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_, std::size_t...OutIndices_, std::size_t...DpIndices_>
 	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_mat
 	(
 		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
@@ -487,7 +487,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		}
 	}
 
-	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	template<typename OutT_, EmuConcepts::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
 	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_mat(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
 	{
 		using mat_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
@@ -664,7 +664,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 	template
 	<
 		std::size_t OutIndex_, std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_,
-		EmuMath::TMP::EmuMatrix Matrix_, std::size_t...DpIndices_
+		EmuConcepts::EmuMatrix Matrix_, std::size_t...DpIndices_
 	>
 	constexpr inline void _matrix_std_multiply_assign_index_vector_mat
 	(
@@ -705,7 +705,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 
 	template
 	<
-		std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_,
+		std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuConcepts::EmuMatrix Matrix_,
 		std::size_t...OutIndices_, std::size_t...DpIndices_
 	>
 	constexpr inline void _matrix_std_multiply_assign_vector_mat
@@ -739,7 +739,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		}
 	}
 
-	template<std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_>
+	template<std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuConcepts::EmuMatrix Matrix_>
 	constexpr inline void _matrix_std_multiply_assign_vector_mat
 	(
 		EmuMath::Vector<OutSize_, OutT_>& out_vector_,
@@ -753,7 +753,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		_matrix_std_multiply_assign_vector_mat(out_indices(), dp_indices(), out_vector_, lhs_vector_, rhs_matrix_);
 	}
 
-	template<std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_>
+	template<std::size_t LhsSize_, typename LhsT_, EmuConcepts::EmuMatrix Matrix_>
 	constexpr inline void _matrix_std_multiply_assign_vector_mat
 	(
 		EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_special_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_special_arithmetic.h
@@ -289,27 +289,30 @@ namespace EmuMath::Helpers::_matrix_underlying
 #pragma endregion
 
 #pragma region MATRIX_MUL_VECTOR
-	template<std::size_t DpIndex_, std::size_t RowIndex_, class LhsMatrix_, class RhsVector_>
-	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_calculate_dp_mult(const LhsMatrix_& lhs_mat_, const RhsVector_& rhs_vector_)
+	template<std::size_t DpIndex_, std::size_t OtherIndex_, bool VectorLhs_, class LhsMatrix_, class RhsVector_>
+	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_calculate_dp_mult(const LhsMatrix_& matrix_, const RhsVector_& vector_)
 	{
+		constexpr std::size_t column_index = VectorLhs_ ? OtherIndex_ : DpIndex_;
+		constexpr std::size_t row_index = VectorLhs_ ? DpIndex_ : OtherIndex_;
+
 		if constexpr (DpIndex_ < EmuCore::TMP::remove_ref_cv_t<RhsVector_>::size)
 		{
-			using lhs_get_uq = EmuCore::TMP::remove_ref_cv_t<decltype(lhs_mat_.template at<DpIndex_, RowIndex_>())>;
-			using rhs_get_uq = EmuCore::TMP::remove_ref_cv_t<decltype(rhs_vector_.template at<DpIndex_>())>;
+			using lhs_get_uq = EmuCore::TMP::remove_ref_cv_t<decltype(matrix_.template at<column_index, row_index>())>;
+			using rhs_get_uq = EmuCore::TMP::remove_ref_cv_t<decltype(vector_.template at<DpIndex_>())>;
 			return EmuCore::do_multiply<lhs_get_uq, rhs_get_uq>()
 			(
-				lhs_mat_.template at<DpIndex_, RowIndex_>(),
-				rhs_vector_.template at<DpIndex_>()
+				matrix_.template at<column_index, row_index>(),
+				vector_.template at<DpIndex_>()
 			);
 		}
 		else
 		{
-			return lhs_mat_.template at<DpIndex_, RowIndex_>();
+			return matrix_.template at<column_index, row_index>();
 		}
 	}
 
 	template<std::size_t Index_, class OutVector_, class LhsMatrix_, class RhsVector_, std::size_t...DpIndices_>
-	[[nodiscard]] constexpr inline typename OutVector_::stored_type _matrix_std_multiply_mat_vector_dp_for_index
+	[[nodiscard]] constexpr inline typename decltype(auto) _matrix_std_multiply_mat_vector_dp_for_index
 	(
 		const LhsMatrix_& lhs_matrix_,
 		const RhsVector_& rhs_vector_
@@ -317,12 +320,12 @@ namespace EmuMath::Helpers::_matrix_underlying
 	{
 		return EmuCore::TMP::construct_or_cast<typename OutVector_::stored_type>
 		(
-			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_>(lhs_matrix_, rhs_vector_) + ...)
+			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_, false>(lhs_matrix_, rhs_vector_) + ...)
 		);
 	}
 
 	template<std::size_t Index_, class LhsMatrix_, class RhsVector_, std::size_t...DpIndices_>
-	[[nodiscard]] constexpr inline auto _matrix_std_multiply_mat_vector_dp_for_assigned_index
+	[[nodiscard]] constexpr inline decltype(auto) _matrix_std_multiply_mat_vector_dp_for_assigned_index
 	(
 		const LhsMatrix_& lhs_matrix_,
 		const RhsVector_& rhs_vector_
@@ -330,7 +333,33 @@ namespace EmuMath::Helpers::_matrix_underlying
 	{
 		return
 		(
-			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_>(lhs_matrix_, rhs_vector_) + ...)
+			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_, false>(lhs_matrix_, rhs_vector_) + ...)
+		);
+	}
+
+	template<std::size_t Index_, EmuMath::TMP::EmuVector OutVector_, EmuMath::TMP::EmuVector LhsVector_, EmuMath::TMP::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
+	[[nodiscard]] constexpr inline typename decltype(auto) _matrix_std_multiply_vector_mat_dp_for_index
+	(
+		const LhsVector_& lhs_vector_,
+		const RhsMatrix_& rhs_matrix_
+	)
+	{
+		return EmuCore::TMP::construct_or_cast<typename OutVector_::stored_type>
+		(
+			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_, true>(rhs_matrix_, lhs_vector_) + ...)
+		);
+	}
+
+	template<std::size_t Index_, EmuMath::TMP::EmuVector LhsVector_, EmuMath::TMP::EmuMatrix RhsMatrix_, std::size_t...DpIndices_>
+	[[nodiscard]] constexpr inline decltype(auto) _matrix_std_multiply_vector_mat_dp_for_assigned_index
+	(
+		const LhsVector_& lhs_vector_,
+		const RhsMatrix_& rhs_matrix_
+	)
+	{
+		return
+		(
+			(_matrix_std_multiply_vector_calculate_dp_mult<DpIndices_, Index_, true>(rhs_matrix_, lhs_vector_) + ...)
 		);
 	}
 
@@ -375,7 +404,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 				static_assert
 				(
 					EmuCore::TMP::get_false<OutVector_>(),
-					"Attempted to standard-multiply an EmuMath Matrix and EmuMath Vector, but the provided output Vector cannot be constructed from one stored_type per contained element."
+					"Attempted to standard-multiply an EmuMath Matrix and EmuMath Vector (MAT * VEC), but the provided output Vector cannot be constructed from one stored_type per contained element."
 				);
 			}
 		}
@@ -384,7 +413,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 			static_assert
 			(
 				EmuCore::TMP::get_false<std::size_t, RhsSize_>(),
-				"Attempted to standard-multiply an EmuMath Matrix and EmuMath Vector, but the provided Vector has a number of elements not equal to the Matrix's number of rows, or its number of rows - 1."
+				"Attempted to standard-multiply an EmuMath Matrix and EmuMath Vector (MAT * VEC), but the provided Vector has a number of elements not equal to the Matrix's number of rows, or its number of rows - 1."
 			);
 		}
 	}
@@ -399,6 +428,78 @@ namespace EmuMath::Helpers::_matrix_underlying
 		using out_indices = std::make_index_sequence<RhsSize_>;
 		using dp_indices = std::make_index_sequence<LhsNumRows_>;
 		return _matrix_std_multiply_mat_vector<EmuMath::Vector<RhsSize_, OutT_>>(out_indices(), dp_indices(), lhs_matrix_, rhs_vector_);
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_, std::size_t...OutIndices_, std::size_t...DpIndices_>
+	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_mat
+	(
+		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		const Matrix_& rhs_matrix_,
+		std::index_sequence<OutIndices_...> out_indices_,
+		std::index_sequence<DpIndices_...> dp_indices_
+	)
+	{
+		using rhs_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+		constexpr std::size_t rhs_num_columns = rhs_uq::num_columns;
+
+		if constexpr (LhsSize_ == rhs_num_columns || (LhsSize_ + 1) == rhs_num_columns)
+		{
+			using lhs_vector_type = EmuMath::Vector<LhsSize_, LhsT_>;
+			constexpr bool is_constructible_ = std::is_constructible_v
+			<
+				EmuMath::Vector<LhsSize_, LhsT_>,
+				decltype
+				(
+					_matrix_std_multiply_vector_mat_dp_for_index<OutIndices_, EmuMath::Vector<LhsSize_, OutT_>, lhs_vector_type, rhs_uq, DpIndices_...>
+					(
+						lhs_vector_,
+						rhs_matrix_
+					)
+				)...
+			>;
+			if constexpr (is_constructible_)
+			{
+				return EmuMath::Vector<LhsSize_, OutT_>
+				(
+					_matrix_std_multiply_vector_mat_dp_for_index<OutIndices_, EmuMath::Vector<LhsSize_, OutT_>, lhs_vector_type, rhs_uq, DpIndices_...>
+					(
+						lhs_vector_,
+						rhs_matrix_
+					)...
+				);
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<EmuMath::Vector<LhsSize_, OutT_>>(),
+					"Attempted to standard-multiply an EmuMath Vector and EmuMath Matrix¬ (VEC * MAT), but the provided output Vector cannot be constructed from one stored_type per contained element."
+				);
+			}
+		}
+		else
+		{
+			static_assert
+			(
+				EmuCore::TMP::get_false<std::size_t, LhsSize_>(),
+				"Attempted to standard-multiply an EmuMath Vector and EmuMath Matrix (VEC * MAT), but the provided Vector has a number of elements not equal to the Matrix's number of columns, or its number of columns - 1."
+			);
+		}
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuMatrix Matrix_, std::size_t LhsSize_, typename LhsT_>
+	[[nodiscard]] constexpr inline auto _matrix_std_multiply_vector_mat(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
+	{
+		using mat_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+		using out_indices = std::make_index_sequence<LhsSize_>;
+		using dp_indices = std::make_index_sequence<mat_uq::num_columns>;
+		return _matrix_std_multiply_vector_mat<OutT_>
+		(
+			lhs_vector_,
+			EmuCore::TMP::const_lval_ref_cast<Matrix_>(std::forward<Matrix_>(rhs_matrix_)),
+			out_indices(),
+			dp_indices()
+		);
 	}
 #pragma endregion
 
@@ -518,7 +619,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		const EmuMath::Vector<RhsSize_, RhsT_>& rhs_vector_
 	)
 	{
-		using out_indices = std::make_index_sequence<RhsSize_>;
+		using out_indices = std::make_index_sequence<(OutSize_ < RhsSize_) ? OutSize_ : RhsSize_>;
 		using dp_indices = std::make_index_sequence<LhsNumRows_>;
 		_matrix_std_multiply_assign_mat_vector(out_indices(), dp_indices(), out_vector_, lhs_matrix_, rhs_vector_);
 	}
@@ -549,6 +650,135 @@ namespace EmuMath::Helpers::_matrix_underlying
 				(
 					EmuCore::TMP::get_false<rhs_copy_type>(),
 					"Attempted to perform a standard Matrix multiply-assign with an EmuMath Matrix and EmuMath Vector, with assignment going to the Vector. However, the provided Vector type could not successfully be copied to retain data for each assignment."
+				);
+			}
+		}
+	}
+
+
+
+
+
+	
+
+	template
+	<
+		std::size_t OutIndex_, std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_,
+		EmuMath::TMP::EmuMatrix Matrix_, std::size_t...DpIndices_
+	>
+	constexpr inline void _matrix_std_multiply_assign_index_vector_mat
+	(
+		EmuMath::Vector<OutSize_, OutT_>& out_vector_,
+		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		const Matrix_& rhs_matrix_
+	)
+	{
+		if constexpr (OutIndex_ < OutSize_)
+		{
+			using lhs_uq = EmuMath::Vector<LhsSize_, LhsT_>;
+			using rhs_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+			using out_get_result = decltype(out_vector_.template at<OutIndex_>());
+			using dp_result = decltype
+			(
+				_matrix_std_multiply_vector_mat_dp_for_assigned_index<OutIndex_, lhs_uq, rhs_uq, DpIndices_...>(lhs_vector_, rhs_matrix_)
+			);
+			using out_value_uq = typename EmuMath::Vector<OutSize_, OutT_>::value_type_uq;
+
+			if constexpr (EmuCore::TMP::valid_assign_direct_or_cast<out_value_uq, dp_result, out_get_result>())
+			{
+				EmuCore::TMP::assign_direct_or_cast<out_value_uq>
+				(
+					out_vector_.template at<OutIndex_>(),
+					_matrix_std_multiply_vector_mat_dp_for_assigned_index<OutIndex_, lhs_uq, rhs_uq, DpIndices_...>(lhs_vector_, rhs_matrix_)
+				);
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<OutT_>(),
+					"Attempted to standard multiply-assign an EmuMath Vector and EmuMath Matrix (VEC * MAT), but the provided output Vector could not have one of its indices assigned from the result from at least one iteration's dot product."
+				);
+			}
+		}
+	}
+
+	template
+	<
+		std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_,
+		std::size_t...OutIndices_, std::size_t...DpIndices_
+	>
+	constexpr inline void _matrix_std_multiply_assign_vector_mat
+	(
+		std::index_sequence<OutIndices_...> out_indices_,
+		std::index_sequence<DpIndices_...> dp_indices_,
+		EmuMath::Vector<OutSize_, OutT_>& out_vector_,
+		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		const Matrix_& rhs_matrix_
+	)
+	{
+		using mat_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+		if constexpr (LhsSize_ == mat_uq::num_columns || (LhsSize_ + 1) == mat_uq::num_columns)
+		{
+			(
+				_matrix_std_multiply_assign_index_vector_mat<OutIndices_, OutSize_, OutT_, LhsSize_, LhsT_, Matrix_, DpIndices_...>
+				(
+					out_vector_,
+					lhs_vector_,
+					rhs_matrix_
+				), ...
+			);
+		}
+		else
+		{
+			static_assert
+			(
+				!EmuCore::TMP::get_false<std::size_t, LhsSize_>(),
+				"Attempted to standard multiply-assign an EmuMath Vector and EmuMath Matrix (VEC * MAT), but the provided Vector has a number of elements not equal to the Matrix's number of columns, or its number of columns - 1."
+			);
+		}
+	}
+
+	template<std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_>
+	constexpr inline void _matrix_std_multiply_assign_vector_mat
+	(
+		EmuMath::Vector<OutSize_, OutT_>& out_vector_,
+		const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		Matrix_&& rhs_matrix_
+	)
+	{
+		using rhs_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+		using out_indices = std::make_index_sequence<OutSize_ < LhsSize_ ? OutSize_ : LhsSize_>;
+		using dp_indices = std::make_index_sequence<rhs_uq::num_columns>;
+		_matrix_std_multiply_assign_vector_mat(out_indices(), dp_indices(), out_vector_, lhs_vector_, rhs_matrix_);
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, EmuMath::TMP::EmuMatrix Matrix_>
+	constexpr inline void _matrix_std_multiply_assign_vector_mat
+	(
+		EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_,
+		Matrix_&& rhs_matrix_
+	)
+	{
+		if constexpr (LhsSize_ == 1)
+		{
+			// No need for a temp copy
+			_matrix_std_multiply_assign_vector_mat(lhs_vector_, std::forward<Matrix_>(rhs_matrix_), lhs_vector_);
+		}
+		else
+		{
+			// Need a copy as referenced data which will be modified will need to be used multiple times
+			using lhs_copy_type = EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>;
+			if constexpr (std::is_constructible_v<lhs_copy_type, EmuMath::Vector<LhsSize_, LhsT_>&>)
+			{
+				_matrix_std_multiply_assign_vector_mat(lhs_vector_, lhs_copy_type(lhs_vector_), std::forward<Matrix_>(rhs_matrix_));
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<lhs_copy_type>(),
+					"Attempted to perform a standard Matrix multiply-assign with an EmuMath Vector and EmuMath Matrix (VEC * MAT), with assignment going to the Vector. However, the provided Vector type could not successfully be copied to retain data after each assignment."
 				);
 			}
 		}

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
@@ -3,6 +3,7 @@
 
 #include "../../../../EmuCore/TMPHelpers/TypeConvertors.h"
 #include "../../../Quaternion.h"
+#include "../../../Rect.h"
 #include "../../../Vector.h"
 #include <type_traits>
 
@@ -35,6 +36,9 @@ namespace EmuMath::TMP
 	};
 	template<typename T_>
 	static constexpr bool is_emu_matrix_v = is_emu_matrix<T_>::value;
+
+	template<typename T_>
+	concept EmuMatrix = is_emu_matrix_v<T_>;
 
 	template<std::size_t ColumnIndex_, std::size_t RowIndex_, class Matrix_>
 	struct is_theoretical_matrix_index

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_tmp.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_MATRIX_TMP_H_INC_
 #define EMU_MATH_MATRIX_TMP_H_INC_ 1
 
+#include "../../__common/_common_math_tmp.h"
 #include "../../../../EmuCore/TMPHelpers/TypeConvertors.h"
 #include "../../../Quaternion.h"
 #include "../../../Rect.h"
@@ -15,30 +16,11 @@ namespace EmuMath
 
 namespace EmuMath::TMP
 {
-	/// <summary>
-	/// <para> Type to determine if the passed T_ is a type of EmuMath Matrix. </para>
-	/// <para> The value will be true if T_ is a reference to an EmuMath Matrix, and ignores const/ref qualifiers. </para>
-	/// </summary>
-	template<typename T_>
-	struct is_emu_matrix
-	{
-		static constexpr bool value = std::conditional_t
-		<
-			std::is_same_v<T_, EmuCore::TMP::remove_ref_cv_t<T_>>,
-			std::false_type,
-			is_emu_matrix<EmuCore::TMP::remove_ref_cv_t<T_>>
-		>::value;
-	};
 	template<std::size_t NumColumns_, std::size_t NumRows_, typename T_, bool ColumnMajor_>
 	struct is_emu_matrix<EmuMath::Matrix<NumColumns_, NumRows_, T_, ColumnMajor_>>
 	{
 		static constexpr bool value = true;
 	};
-	template<typename T_>
-	static constexpr bool is_emu_matrix_v = is_emu_matrix<T_>::value;
-
-	template<typename T_>
-	concept EmuMatrix = is_emu_matrix_v<T_>;
 
 	template<std::size_t ColumnIndex_, std::size_t RowIndex_, class Matrix_>
 	struct is_theoretical_matrix_index

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_projections.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_projections.h
@@ -1,0 +1,6 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_PROJECTIONS_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_PROJECTIONS_H_INC_ 1
+
+#include "_underlying_projections/_matrix_underlying_perspective.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_projections.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_matrix_underlying_projections.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_MATRIX_UNDERLYING_PROJECTIONS_H_INC_
 #define EMU_MATH_MATRIX_UNDERLYING_PROJECTIONS_H_INC_ 1
 
+#include "_underlying_projections/_matrix_underlying_ortho.h"
 #include "_underlying_projections/_matrix_underlying_perspective.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
@@ -8,7 +8,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 #pragma region GENERATION_COMPONENTS_VK_ORTHO
 	template
 	<
-		std::size_t ColumnIndex_, std::size_t RowIndex_, EmuMath::TMP::EmuMatrix OutMatrix_,
+		std::size_t ColumnIndex_, std::size_t RowIndex_, EmuConcepts::EmuMatrix OutMatrix_,
 		typename Out00_, typename Out11_, typename Out22_, typename Out30_, typename Out31_, typename Out32_
 	>
 	[[nodiscard]] constexpr inline decltype(auto) _make_orth_vk_arg_for_index
@@ -69,7 +69,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 
 	template
 	<
-		typename CalcType_, EmuMath::TMP::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_,
+		typename CalcType_, EmuConcepts::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_,
 		std::size_t...ColumnIndices_, std::size_t...RowIndices_
 	>
 	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk
@@ -128,7 +128,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 #pragma warning(pop)
 	}
 
-	template<EmuMath::TMP::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_>
+	template<EmuConcepts::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_>
 	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_, Near_&& near_, Far_&& far_)
 	{
 		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
@@ -158,7 +158,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 		);
 	}
 
-	template<EmuMath::TMP::EmuMatrix OutMatrix_, EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_>
+	template<EmuConcepts::EmuMatrix OutMatrix_, EmuConcepts::EmuRect ViewRect_, typename Near_, typename Far_>
 	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
 	{
 		using EmuMath::Helpers::rect_get_left;

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
@@ -6,8 +6,198 @@
 namespace EmuMath::Helpers::_matrix_underlying
 {
 #pragma region GENERATION_COMPONENTS_VK_ORTHO
-	// TODO
+	template
+	<
+		std::size_t ColumnIndex_, std::size_t RowIndex_, EmuMath::TMP::EmuMatrix OutMatrix_,
+		typename Out00_, typename Out11_, typename Out22_, typename Out30_, typename Out31_, typename Out32_
+	>
+	[[nodiscard]] constexpr inline decltype(auto) _make_orth_vk_arg_for_index
+	(
+		Out00_&& out_00_,
+		Out11_&& out_11_,
+		Out22_&& out_22_,
+		Out30_&& out_30_,
+		Out31_&& out_31_,
+		Out32_&& out_32_
+	)
+	{
+		if constexpr (ColumnIndex_ == 0 && RowIndex_ == 0)
+		{
+			return std::forward<Out00_>(out_00_);
+		}
+		else if constexpr (ColumnIndex_ == 1 && RowIndex_ == 1)
+		{
+			return std::forward<Out11_>(out_11_);
+		}
+		else if constexpr (ColumnIndex_ == 2 && RowIndex_ == 2)
+		{
+			return std::forward<Out22_>(out_22_);
+		}
+		else if constexpr (ColumnIndex_ == 3)
+		{
+			if constexpr (RowIndex_ == 0)
+			{
+				return std::forward<Out30_>(out_30_);
+			}
+			else if constexpr (RowIndex_ == 1)
+			{
+				return std::forward<Out31_>(out_31_);
+			}
+			else if constexpr (RowIndex_ == 2)
+			{
+				return std::forward<Out32_>(out_32_);
+			}
+			else if constexpr (RowIndex_ == 3)
+			{
+				using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+				return typename out_mat_uq::value_type_uq(1);
+			}
+		}
+		else if constexpr (ColumnIndex_ == RowIndex_)
+		{
+			// All 1 on remaining main diagonal
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return typename out_mat_uq::value_type_uq(1);
+		}
+		else
+		{
+			// All zero elsewhere
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return out_mat_uq::get_implied_zero();
+		}
+	}
+
+	template
+	<
+		typename CalcType_, EmuMath::TMP::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_,
+		std::size_t...ColumnIndices_, std::size_t...RowIndices_
+	>
+	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk
+	(
+		Left_&& left_,
+		Top_&& top_,
+		Right_&& right_,
+		Bottom_&& bottom_,
+		Near_&& near_,
+		Far_&& far_,
+		std::index_sequence<ColumnIndices_...> column_indices_,
+		std::index_sequence<RowIndices_...> row_indices_
+	)
+	{
+		CalcType_ left = static_cast<CalcType_>(std::forward<Left_>(left_));
+		CalcType_ top = static_cast<CalcType_>(std::forward<Top_>(top_));
+		CalcType_ right = static_cast<CalcType_>(std::forward<Right_>(right_));
+		CalcType_ bottom = static_cast<CalcType_>(std::forward<Bottom_>(bottom_));
+		CalcType_ near = static_cast<CalcType_>(std::forward<Near_>(near_));
+		CalcType_ far = static_cast<CalcType_>(std::forward<Far_>(far_));
+
+		using add_func = EmuCore::do_add<CalcType_, CalcType_>;
+		using sub_func = EmuCore::do_subtract<CalcType_, CalcType_>;
+		using div_func = EmuCore::do_divide<CalcType_, CalcType_>;
+		using negate_func = EmuCore::do_negate<CalcType_>;
+
+		// Prepare 3x3 diagonal
+		CalcType_ out_00 = sub_func()(right, left); // 2 / (right - left); Divides at end as (right - left) is used more than once
+		CalcType_ out_11 = sub_func()(bottom, top); // 2 / (bottom - top); Divides at end as (bottom - top) is used more than once
+		CalcType_ out_22 = sub_func()(near, far);	// 1 / (near - far); Divides at end as (near - far) is used more than once
+
+		// End chunk
+		CalcType_ out_30 = div_func()(negate_func()(add_func()(right, left)), out_00); // -(right + left) / (right - left)
+		CalcType_ out_31 = div_func()(negate_func()(add_func()(bottom, top)), out_11); // -(bottom + top) / (bottom - top)
+		CalcType_ out_32 = div_func()(near, out_22); // near / (near - far)
+
+		// Divide 3x3 diagonals
+		out_00 = div_func()(CalcType_(2), out_00);
+		out_11 = div_func()(CalcType_(2), out_11);
+		out_22 = div_func()(CalcType_(1), out_22);
+
+#pragma warning(push) // Silence duplicate move warnings here as no input value will be used twice
+#pragma warning(disable: 26800)
+		return OutMatrix_
+		(
+			_make_orth_vk_arg_for_index<ColumnIndices_, RowIndices_, OutMatrix_>
+			(
+				std::move(out_00),
+				std::move(out_11),
+				std::move(out_22),
+				std::move(out_30),
+				std::move(out_31),
+				std::move(out_32)
+			)...
+		);
+#pragma warning(pop)
+	}
+
+	template<EmuMath::TMP::EmuMatrix OutMatrix_, typename Left_, typename Top_, typename Right_, typename Bottom_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_, Near_&& near_, Far_&& far_)
+	{
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using out_fp = typename out_uq::preferred_floating_point;
+		using left_uq = typename EmuCore::TMP::remove_ref_cv<Left_>::type;
+		using top_uq = typename EmuCore::TMP::remove_ref_cv<Top_>::type;
+		using right_uq = typename EmuCore::TMP::remove_ref_cv<Right_>::type;
+		using bottom_uq = typename EmuCore::TMP::remove_ref_cv<Bottom_>::type;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, left_uq, top_uq, right_uq, bottom_uq, near_uq, far_uq>::type;
+
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_uq>;
+		using out_column_indices = typename out_indices::column_index_sequence;
+		using out_row_indices = typename out_indices::row_index_sequence;
+
+		return _make_ortho_vk<calc_fp, OutMatrix_>
+		(
+			std::forward<Left_>(left_),
+			std::forward<Top_>(top_),
+			std::forward<Right_>(right_),
+			std::forward<Bottom_>(bottom_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_),
+			out_column_indices(),
+			out_row_indices()
+		);
+	}
+
+	template<EmuMath::TMP::EmuMatrix OutMatrix_, EmuMath::TMP::EmuRect ViewRect_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline OutMatrix_ _make_ortho_vk(ViewRect_&& view_rect_, Near_&& near_, Far_&& far_)
+	{
+		using EmuMath::Helpers::rect_get_left;
+		using EmuMath::Helpers::rect_get_top;
+		using EmuMath::Helpers::rect_get_right;
+		using EmuMath::Helpers::rect_get_bottom;
+
+		using get_left_result = decltype(rect_get_left(std::forward<ViewRect_>(view_rect_)));
+		using get_top_result = decltype(rect_get_top(std::forward<ViewRect_>(view_rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<ViewRect_>(view_rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<ViewRect_>(view_rect_)));
+
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<ViewRect_>::type;
+		using out_fp = typename out_uq::preferred_floating_point;
+		using rect_fp = typename rect_uq::preferred_floating_point;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, rect_fp, near_uq, far_uq>::type;
+
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_uq>;
+		using out_column_indices = typename out_indices::column_index_sequence;
+		using out_row_indices = typename out_indices::row_index_sequence;
+
+		return _make_ortho_vk<calc_fp, OutMatrix_>
+		(
+#pragma warning(push) // Specifically silence the rect retrieval functions since we know there are no duplicate moves happening there
+#pragma warning(disable: 26800)
+			std::forward<get_left_result>(rect_get_left(std::forward<ViewRect_>(view_rect_))),
+			std::forward<get_top_result>(rect_get_top(std::forward<ViewRect_>(view_rect_))),
+			std::forward<get_right_result>(rect_get_right(std::forward<ViewRect_>(view_rect_))),
+			std::forward<get_bottom_result>(rect_get_bottom(std::forward<ViewRect_>(view_rect_))),
+#pragma warning(pop)
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_),
+			out_column_indices(),
+			out_row_indices()
+		);
+	}
 #pragma endregion
 }
-
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_ortho.h
@@ -1,0 +1,13 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_PROJECTION_ORTHO_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_PROJECTION_ORTHO_H_INC_ 1
+
+#include "../_matrix_tmp.h"
+
+namespace EmuMath::Helpers::_matrix_underlying
+{
+#pragma region GENERATION_COMPONENTS_VK_ORTHO
+	// TODO
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
@@ -67,6 +67,8 @@ namespace EmuMath::Helpers::_matrix_underlying
 		out_22 = EmuCore::do_divide<calc_fp, calc_fp>()(out_22, EmuCore::do_subtract<calc_fp, calc_fp>()(far, out_22));
 		calc_fp focal_length = static_cast<calc_fp>(std::forward<FocalLength_>(focal_length_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return OutMatrix_
 		(
 			_make_perspective_arg_vk_reverse_depth<ColumnIndices_, RowIndices_, OutMatrix_, calc_fp>
@@ -74,9 +76,10 @@ namespace EmuMath::Helpers::_matrix_underlying
 				std::forward<AspectRatio_>(aspect_ratio_),
 				out_22,
 				far,
-				focal_length
+				focal_length 
 			)...
 		);
+#pragma warning(pop)
 	}
 
 	template<class OutMatrix_, bool FovRads_, bool IsConstexpr_, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
@@ -123,6 +123,128 @@ namespace EmuMath::Helpers::_matrix_underlying
 		);
 	}
 #pragma endregion
+
+#pragma region GENERATION_COMPONENTS_VK
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename CalcFP_, EmuMath::TMP::EmuMatrix OutMatrix_>
+	[[nodiscard]] constexpr inline decltype(auto) _make_perspective_arg_vk
+	(
+		const CalcFP_& aspect_ratio_,
+		const CalcFP_& near_,
+		const CalcFP_& far_,
+		const CalcFP_& focal_length_
+	)
+	{
+		using sub_func = EmuCore::do_subtract<CalcFP_, CalcFP_>;
+		using mul_func = EmuCore::do_multiply<CalcFP_, CalcFP_>;
+		using div_func = EmuCore::do_divide<CalcFP_, CalcFP_>;
+
+		if constexpr (ColumnIndex_ == 0 && RowIndex_ == 0)
+		{
+			return div_func()(CalcFP_(1), mul_func()(aspect_ratio_, focal_length_));
+		}
+		else if constexpr (ColumnIndex_ == 1 && RowIndex_ == 1)
+		{
+			return div_func()(CalcFP_(1), focal_length_);
+		}
+		else if constexpr (ColumnIndex_ == 2 && RowIndex_ == 2)
+		{
+			return div_func()(far_, sub_func()(near_, far_));
+		}
+		else if constexpr (ColumnIndex_ == 2 && RowIndex_ == 3)
+		{
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return typename out_mat_uq::value_type_uq(-1);
+		}
+		else if constexpr (ColumnIndex_ == 3 && RowIndex_ == 2)
+		{
+			using negate_func = EmuCore::do_negate<CalcFP_>;
+			return div_func()(negate_func()(mul_func()(far_, near_)), sub_func()(far_, near_));
+		}
+		else
+		{
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return out_mat_uq::get_implied_zero();
+		}
+	}
+
+	template<class OutMatrix_, typename FocalLength_, typename AspectRatio_, typename Near_, typename Far_, std::size_t...ColumnIndices_, std::size_t...RowIndices_>
+	[[nodiscard]] constexpr inline OutMatrix_ _construct_perspective_matrix_vk
+	(
+		AspectRatio_&& aspect_ratio_,
+		Near_&& near_,
+		Far_&& far_,
+		FocalLength_&& focal_length_,
+		std::index_sequence<ColumnIndices_...> column_indices_,
+		std::index_sequence<RowIndices_...> row_indices_
+	)
+	{
+		using focal_length_uq = typename EmuCore::TMP::remove_ref_cv<FocalLength_>::type;
+		using aspect_ratio_uq = typename EmuCore::TMP::remove_ref_cv<AspectRatio_>::type;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using out_fp = typename out_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, far_uq, near_uq, aspect_ratio_uq, focal_length_uq>::type;
+
+		calc_fp aspect_ratio = static_cast<calc_fp>(std::forward<AspectRatio_>(aspect_ratio_));
+		calc_fp near = static_cast<calc_fp>(std::forward<Near_>(near_));
+		calc_fp far = static_cast<calc_fp>(std::forward<Far_>(far_));
+		calc_fp focal_length = static_cast<calc_fp>(std::forward<FocalLength_>(focal_length_));
+
+
+
+		return OutMatrix_
+		(
+			_make_perspective_arg_vk<ColumnIndices_, RowIndices_, calc_fp, OutMatrix_>
+			(
+				aspect_ratio,
+				near,
+				far,
+				focal_length
+			)...
+		);
+	}
+
+	template<class OutMatrix_, bool FovRads_, bool IsConstexpr_, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline OutMatrix_ _make_perspective_matrix_vk
+	(
+		FovY_&& fov_y_,
+		AspectRatio_&& aspect_ratio_,
+		Near_&& near_,
+		Far_&& far_
+	)
+	{
+		using fov_uq = typename EmuCore::TMP::remove_ref_cv<FovY_>::type;
+		using aspect_ratio_uq = typename EmuCore::TMP::remove_ref_cv<AspectRatio_>::type;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using out_fp = typename out_mat_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, far_uq, near_uq, aspect_ratio_uq, fov_uq>::type;
+
+		calc_fp focal_length = static_cast<calc_fp>(std::forward<FovY_>(fov_y_)); // focal_length = 1 / tan(fov_y_rads / 2)
+		if constexpr (!FovRads_)
+		{
+			focal_length = EmuCore::Pi::DegsToRads<calc_fp>(focal_length);
+		}
+		using tan_func = typename std::conditional<IsConstexpr_, EmuCore::do_tan_constexpr<calc_fp>, EmuCore::do_tan<calc_fp>>::type;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+		focal_length = tan_func()(div_func()(focal_length, calc_fp(2)));
+
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_mat_uq>;
+		using column_index_sequence = typename out_indices::column_index_sequence;
+		using row_index_sequence = typename out_indices::row_index_sequence;
+		return _construct_perspective_matrix_vk<OutMatrix_>
+		(
+			std::forward<AspectRatio_>(aspect_ratio_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_),
+			focal_length,
+			column_index_sequence(),
+			row_index_sequence()
+		);
+	}
+#pragma endregion
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
@@ -125,7 +125,7 @@ namespace EmuMath::Helpers::_matrix_underlying
 #pragma endregion
 
 #pragma region GENERATION_COMPONENTS_VK
-	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename CalcFP_, EmuMath::TMP::EmuMatrix OutMatrix_>
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, typename CalcFP_, EmuConcepts::EmuMatrix OutMatrix_>
 	[[nodiscard]] constexpr inline decltype(auto) _make_perspective_arg_vk
 	(
 		const CalcFP_& aspect_ratio_,

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_projections/_matrix_underlying_perspective.h
@@ -1,0 +1,125 @@
+#ifndef EMU_MATH_MATRIX_UNDERLYING_PROJECTION_PERSPECTIVE_H_INC_
+#define EMU_MATH_MATRIX_UNDERLYING_PROJECTION_PERSPECTIVE_H_INC_ 1
+
+#include "../_matrix_tmp.h"
+
+namespace EmuMath::Helpers::_matrix_underlying
+{
+#pragma region GENERATION_COMPONENTS_VK_REVERSE_DEPTH
+	template<std::size_t ColumnIndex_, std::size_t RowIndex_, class OutMatrix_, typename CalcFP_, typename AspectRatio_>
+	[[nodiscard]] constexpr inline decltype(auto) _make_perspective_arg_vk_reverse_depth
+	(
+		AspectRatio_&& aspect_ratio_,
+		const CalcFP_& out_22_,
+		const CalcFP_& far_,
+		const CalcFP_& focal_length_
+	)
+	{
+		if constexpr (ColumnIndex_ == 0 && RowIndex_ == 0)
+		{
+			return EmuCore::do_divide<CalcFP_, CalcFP_>()(focal_length_, static_cast<CalcFP_>(std::forward<AspectRatio_>(aspect_ratio_)));
+		}
+		else if constexpr (ColumnIndex_ == 1 && RowIndex_ == 1)
+		{
+			return EmuCore::do_negate<CalcFP_>()(focal_length_);
+		}
+		else if constexpr (ColumnIndex_ == 2 && RowIndex_ == 2)
+		{
+			return out_22_;
+		}
+		else if constexpr (ColumnIndex_ == 2 && RowIndex_ == 3)
+		{
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return typename out_mat_uq::value_type_uq(-1);
+		}
+		else if constexpr (ColumnIndex_ == 3 && RowIndex_ == 2)
+		{
+			return EmuCore::do_multiply<CalcFP_, CalcFP_>()(far_, out_22_);
+		}
+		else
+		{
+			using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+			return out_mat_uq::get_implied_zero();
+		}
+	}
+
+	template<class OutMatrix_, typename FocalLength_, typename AspectRatio_, typename Near_, typename Far_, std::size_t...ColumnIndices_, std::size_t...RowIndices_>
+	[[nodiscard]] constexpr inline OutMatrix_ _construct_perspective_matrix_vk_reverse_depth
+	(
+		AspectRatio_&& aspect_ratio_,
+		Near_&& near_,
+		Far_&& far_,
+		FocalLength_&& focal_length_,
+		std::index_sequence<ColumnIndices_...> column_indices_,
+		std::index_sequence<RowIndices_...> row_indices_
+	)
+	{
+		using focal_length_uq = typename EmuCore::TMP::remove_ref_cv<FocalLength_>::type;
+		using aspect_ratio_uq = typename EmuCore::TMP::remove_ref_cv<AspectRatio_>::type;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using out_fp = typename out_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, far_uq, near_uq, aspect_ratio_uq, focal_length_uq>::type;
+
+		calc_fp out_22 = static_cast<calc_fp>(std::forward<Near_>(near_)); // near / (far - near); output for c2r2
+		calc_fp far = static_cast<calc_fp>(std::forward<Far_>(far_));
+		out_22 = EmuCore::do_divide<calc_fp, calc_fp>()(out_22, EmuCore::do_subtract<calc_fp, calc_fp>()(far, out_22));
+		calc_fp focal_length = static_cast<calc_fp>(std::forward<FocalLength_>(focal_length_));
+
+		return OutMatrix_
+		(
+			_make_perspective_arg_vk_reverse_depth<ColumnIndices_, RowIndices_, OutMatrix_, calc_fp>
+			(
+				std::forward<AspectRatio_>(aspect_ratio_),
+				out_22,
+				far,
+				focal_length
+			)...
+		);
+	}
+
+	template<class OutMatrix_, bool FovRads_, bool IsConstexpr_, typename FovY_, typename AspectRatio_, typename Near_, typename Far_>
+	[[nodiscard]] constexpr inline OutMatrix_ _make_perspective_matrix_vk_reverse_depth
+	(
+		FovY_&& fov_y_,
+		AspectRatio_&& aspect_ratio_,
+		Near_&& near_,
+		Far_&& far_
+	)
+	{
+		using fov_uq = typename EmuCore::TMP::remove_ref_cv<FovY_>::type;
+		using aspect_ratio_uq = typename EmuCore::TMP::remove_ref_cv<AspectRatio_>::type;
+		using near_uq = typename EmuCore::TMP::remove_ref_cv<Near_>::type;
+		using far_uq = typename EmuCore::TMP::remove_ref_cv<Far_>::type;
+		using out_mat_uq = typename EmuCore::TMP::remove_ref_cv<OutMatrix_>::type;
+		using out_fp = typename out_mat_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_fp, far_uq, near_uq, aspect_ratio_uq, fov_uq>::type;
+
+		calc_fp focal_length = static_cast<calc_fp>(std::forward<FovY_>(fov_y_)); // focal_length = 1 / tan(fov_y_rads / 2)
+		if constexpr (!FovRads_)
+		{
+			focal_length = EmuCore::Pi::DegsToRads<calc_fp>(focal_length);
+		}
+		using tan_func = typename std::conditional<IsConstexpr_, EmuCore::do_tan_constexpr<calc_fp>, EmuCore::do_tan<calc_fp>>::type;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+		focal_length = div_func()(calc_fp(1), tan_func()(div_func()(focal_length, calc_fp(2))));
+
+
+		using out_indices = EmuMath::TMP::make_full_matrix_index_sequences<out_mat_uq>;
+		using column_index_sequence = typename out_indices::column_index_sequence;
+		using row_index_sequence = typename out_indices::row_index_sequence;
+		return _construct_perspective_matrix_vk_reverse_depth<OutMatrix_>
+		(
+			std::forward<AspectRatio_>(aspect_ratio_),
+			std::forward<Near_>(near_),
+			std::forward<Far_>(far_),
+			focal_length,
+			column_index_sequence(),
+			row_index_sequence()
+		);
+	}
+#pragma endregion
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_transformations/_matrix_underlying_translate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_underlying_helpers/_underlying_transformations/_matrix_underlying_translate.h
@@ -14,20 +14,19 @@ namespace EmuMath::Helpers::_matrix_underlying
 		{
 			if constexpr (ColumnIndex_ == (out_mat_uq::num_columns - 1))
 			{
-				constexpr std::size_t tuple_index = RowIndex_;
-				if constexpr (tuple_index < std::tuple_size_v<std::tuple<Args_...>>)
+				if constexpr (RowIndex_ < std::tuple_size_v<std::tuple<Args_...>>)
 				{
 					// Retrieve translation for the dimension, which will be the respective element in the tuple
 					// --- Move if not lvalue reference
 					using std::get;
-					using arg = typename std::tuple_element<tuple_index, std::tuple<Args_...>>::type;
+					using arg = typename std::tuple_element<RowIndex_, std::tuple<Args_...>>::type;
 					if constexpr (std::is_lvalue_reference_v<arg>)
 					{
-						return get<tuple_index>(args_tuple_);
+						return get<RowIndex_>(args_tuple_);
 					}
 					else
 					{
-						return std::move(get<tuple_index>(args_tuple_));
+						return std::move(get<RowIndex_>(args_tuple_));
 					}
 				}
 				else

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_vector_extensions.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_matrix/_vector_extensions.h
@@ -1,0 +1,156 @@
+#ifndef EMU_MATH_MATRIX_VECTOR_EXTENSIONS_H_INC_
+#define EMU_MATH_MATRIX_VECTOR_EXTENSIONS_H_INC_ 1
+
+#include "_helpers/_all_matrix_helpers.h"
+#include "_matrix_t.h"
+
+namespace EmuMath::Helpers
+{
+#pragma region MULTIPLY_VALIDITY
+	template<std::size_t LhsSize_, typename LhsT_, EmuConcepts::EmuMatrix Matrix_, bool StaticAssert_ = false>
+	[[nodiscard]] constexpr inline bool valid_vector_mul_matrix_args()
+	{
+		using _in_mat_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+
+		if constexpr (LhsSize_ == _in_mat_uq::num_columns || LhsSize_ == (_in_mat_uq::num_columns - 1))
+		{
+			return true;
+		}
+		else
+		{
+			static_assert
+			(
+				!StaticAssert_,
+				"Unable to multiply a Vector by a Matrix (VEC * MAT) as the input left-hand Vector does not have a size equal to the number of columns in the right-hand Matrix, or its number of columns - 1."
+			);
+			return false;
+		}
+	}
+
+	template<EmuConcepts::EmuMatrix Matrix_, std::size_t RhsSize_, typename RhsT_, bool StaticAssert_ = false>
+	[[nodiscard]] constexpr inline bool valid_matrix_mul_vector_args()
+	{
+		using _in_mat_uq = typename EmuCore::TMP::remove_ref_cv<Matrix_>::type;
+
+		if constexpr (RhsSize_ == _in_mat_uq::num_rows || RhsSize_ == (_in_mat_uq::num_rows - 1))
+		{
+			return true;
+		}
+		else
+		{
+			static_assert
+			(
+				!StaticAssert_,
+				"Unable to multiply a Matrix by a Vector (MAT * VEC) as the input right-hand Vector does not have a size equal to the number of rows in the left-hand Matrix, or its number of rows - 1."
+			);
+			return false;
+		}
+	}
+#pragma endregion
+
+#pragma region STD_MULTIPLY
+	/// <summary>
+	/// <para> Matrix extension allowing a left-hand row-Vector to be multiplied by a right-hand Column Matrix. </para>
+	/// <para> The left-hand Vector is treated as a single-row Matrix, and must have as many elements as the right-hand Matrix has columns. </para>
+	/// <para> 
+	///		Alternatively, the left-hand Vector may have a number of elements equal to the Matrix's number of columns - 1. 
+	///		In this case, the missing element is treated as 1 for common uses such as transforming 3D Vectors by 4x4 Matrices.
+	/// </para>
+	/// <para>
+	///		Note that Vector multiplication is non-commutative, in that A*B != B*A (with some exceptions). 
+	///		If you are using this to transform Vectors from EmuMath utilities, EmuMath Transformation Matrices are designed to be the right-hand argument by default.
+	/// </para>
+	/// </summary>
+	/// <param name="lhs_vector_">Vector appearing on the left-hand side of multiplication, interpreted as a single-row Matrix.</param>
+	/// <param name="rhs_matrix_">Matrix appearing on the right-hand side of multiplication.</param>
+	/// <returns>Vector resulting from multiplying the VEC * MAT operation, with the passed Vector treated as a single-row Matrix.</returns>
+	template<typename OutT_, EmuConcepts::EmuMatrix Matrix_, typename LhsT_, std::size_t LhsSize_>
+	[[nodiscard]] constexpr inline auto vector_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
+		-> std::enable_if_t<valid_vector_mul_matrix_args<LhsSize_, LhsT_, Matrix_, false>(), EmuMath::Vector<LhsSize_, OutT_>>
+	{
+		return _matrix_underlying::_matrix_std_multiply_vector_mat<OutT_>(lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
+	}
+
+	/// <summary>
+	/// <para> Matrix extension allowing a left-hand column-Vector to be multiplied by a right-hand Row Matrix. </para>
+	/// <para> The left-hand Vector is treated as a single-column Matrix, and must have as many elements as the right-hand Matrix has rows. </para>
+	/// <para> 
+	///		Alternatively, the left-hand Vector may have a number of elements equal to the Matrix's number of rows - 1. 
+	///		In this case, the missing element is treated as 1 for common uses such as transforming 3D Vectors by 4x4 Matrices.
+	/// </para>
+	/// <para>
+	///		Note that Vector multiplication is non-commutative, in that A*B != B*A (with some exceptions). 
+	///		If you are using this to transform Vectors from EmuMath utilities, EmuMath Transformation Matrices are designed to be the right-hand argument by default.
+	/// </para>
+	/// </summary>
+	/// <param name="rhs_matrix_">Matrix appearing on the left-hand side of multiplication.</param>
+	/// <param name="rhs_vector_">Vector appearing on the right-hand side of multiplication, interpreted as a single-column Matrix.</param>
+	/// <returns>Vector resulting from multiplying the MAT * VEC operation, with the passed Vector treated as a single-column Matrix.</returns>
+	template<typename OutT_, EmuConcepts::EmuMatrix LhsMatrix_, typename RhsT_, std::size_t RhsSize_>
+	[[nodiscard]] constexpr inline auto vector_multiply(LhsMatrix_&& lhs_matrix_, const EmuMath::Vector<RhsSize_, RhsT_>& rhs_vector_)
+		-> std::enable_if_t<valid_matrix_mul_vector_args<LhsMatrix_, RhsSize_, RhsT_>, EmuMath::Vector<RhsSize_, OutT_>>
+	{
+		return _matrix_underlying::_matrix_std_multiply_mat_vector<OutT_>(std::forward<LhsMatrix_>(lhs_matrix_), rhs_vector_);
+	}
+#pragma endregion
+}
+
+#pragma region VECTOR_MUL_MAT_OPERATORS
+/// <summary>
+/// <para> Matrix extension to the multiply operator, allowing a left-hand row-Vector to be multiplied by a right-hand Column Matrix. </para>
+/// <para> The left-hand Vector is treated as a single-row Matrix, and must have as many elements as the right-hand Matrix has columns. </para>
+/// <para> 
+///		Alternatively, the left-hand Vector may have a number of elements equal to the Matrix's number of columns - 1. 
+///		In this case, the missing element is treated as 1 for common uses such as transforming 3D Vectors by 4x4 Matrices.
+/// </para>
+/// <para>
+///		Note that Vector multiplication is non-commutative, in that A*B != B*A (with some exceptions). 
+///		If you are using this to transform Vectors from EmuMath utilities, EmuMath Transformation Matrices are designed to be the right-hand argument by default.
+/// </para>
+/// </summary>
+/// <param name="lhs_vector_">Vector appearing on the left-hand side of multiplication, interpreted as a single-row Matrix.</param>
+/// <param name="rhs_matrix_">Matrix appearing on the right-hand side of multiplication.</param>
+/// <returns>Vector resulting from multiplying the VEC * MAT operation, with the passed Vector treated as a single-row Matrix.</returns>
+template<EmuConcepts::EmuMatrix Matrix_, typename LhsT_, std::size_t LhsSize_>
+[[nodiscard]] constexpr inline auto operator*(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::valid_vector_mul_matrix_args<LhsSize_, LhsT_, Matrix_, false>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::_matrix_underlying::_matrix_std_multiply_vector_mat<typename EmuMath::Vector<LhsSize_,LhsT_>::value_type_uq>
+	(
+		lhs_vector_,
+		std::forward<Matrix_>(rhs_matrix_)
+	);
+}
+
+/// <summary>
+/// <para> Matrix extension to the multiply-assign operator, allowing a left-hand row-Vector to be multiplied by a right-hand Column Matrix. </para>
+/// <para> The left-hand Vector is treated as a single-row Matrix, and must have as many elements as the right-hand Matrix has columns. </para>
+/// <para> 
+///		Alternatively, the left-hand Vector may have a number of elements equal to the Matrix's number of columns - 1. 
+///		In this case, the missing element is treated as 1 for common uses such as transforming 3D Vectors by 4x4 Matrices.
+/// </para>
+/// <para>
+///		Note that Vector multiplication is non-commutative, in that A*B != B*A (with some exceptions). 
+///		If you are using this to transform Vectors from EmuMath utilities, EmuMath Transformation Matrices are designed to be the right-hand argument by default.
+/// </para>
+/// </summary>
+/// <param name="lhs_vector_">
+///		Vector appearing on the left-hand side of multiplication, interpreted as a single-row Matrix, and to which results are assigned. 
+///		Be aware that a copy of this may be created to perform the operation correctly.
+/// </param>
+/// <param name="rhs_matrix_">Matrix appearing on the right-hand side of multiplication.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<EmuConcepts::EmuMatrix Matrix_, typename LhsT_, std::size_t LhsSize_>
+constexpr inline auto operator*=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Matrix_&& rhs_matrix_)
+	-> std::enable_if_t<EmuMath::Helpers::valid_vector_mul_matrix_args<LhsSize_, LhsT_, Matrix_, false>(), EmuMath::Vector<LhsSize_, LhsT_>&>
+{
+	EmuMath::Helpers::_matrix_underlying::_matrix_std_multiply_assign_vector_mat(lhs_vector_, std::forward<Matrix_>(rhs_matrix_));
+	return lhs_vector_;
+}
+#pragma endregion
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_quaternions/_underlying_helpers/_quaternion_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_quaternions/_underlying_helpers/_quaternion_tmp.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_QUATERNION_TMP_H_INC_
 #define EMU_MATH_QUATERNION_TMP_H_INC_ 1
 
+#include "../../__common/_common_math_tmp.h"
 #include "../../../Vector.h"
 
 namespace EmuMath
@@ -12,28 +13,10 @@ namespace EmuMath
 namespace EmuMath::TMP
 {
 	template<typename T_>
-	struct is_emu_quaternion
-	{
-	private:
-		using _t_uq = typename EmuCore::TMP::remove_ref_cv<T_>::type;
-
-	public:
-		static constexpr bool value = std::conditional_t
-		<
-			std::is_same_v<T_, _t_uq>,
-			std::false_type,
-			EmuMath::TMP::is_emu_quaternion<_t_uq>
-		>::value;
-	};
-
-	template<typename T_>
 	struct is_emu_quaternion<EmuMath::Quaternion<T_>>
 	{
 		static constexpr bool value = true;
 	};
-
-	template<typename T_>
-	static constexpr bool is_emu_quaternion_v = is_emu_quaternion<T_>::value;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -1,0 +1,7 @@
+#ifndef EMU_MATH_ALL_RECT_HELPERS_H_INC_
+#define EMU_MATH_ALL_RECT_HELPERS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -2,6 +2,8 @@
 #define EMU_MATH_ALL_RECT_HELPERS_H_INC_ 1
 
 #include "_common_rect_helper_includes.h"
+#include "_rect_checks.h"
+#include "_rect_conversions.h"
 #include "_rect_get.h"
 #include "_rect_mutate.h"
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_all_rect_helpers.h
@@ -3,5 +3,6 @@
 
 #include "_common_rect_helper_includes.h"
 #include "_rect_get.h"
+#include "_rect_mutate.h"
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_common_rect_helper_includes.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_common_rect_helper_includes.h
@@ -1,0 +1,6 @@
+#ifndef EMU_MATH_COMMON_RECT_HELPER_INCLUDES_H_INC_
+#define EMU_MATH_COMMON_RECT_HELPER_INCLUDES_H_INC_ 1
+
+#include "../_underlying_helpers/_rect_tmp.h"
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -1,0 +1,133 @@
+#ifndef EMU_MATH_RECT_CHECKS_H_INC_
+#define EMU_MATH_RECT_CHECKS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect has a well-formed X axis. </para>
+	/// <para> A well-formed X-axis will have a Left value less than or equal to its Right value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's X-axis is well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_has_well_formed_x(Rect_&& rect_)
+	{
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_left_result>::type;
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_right_result>::type;
+		using cmp = EmuCore::do_cmp_less_equal<get_left_uq, get_right_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return cmp()
+		(
+			std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_))),
+			std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect has a well-formed Y axis. </para>
+	/// <para> A well-formed Y-axis will have a Top value less than or equal to its Bottom value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's Y-axis is well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_has_well_formed_y(Rect_&& rect_)
+	{
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_top_result>::type;
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_bottom_result>::type;
+		using cmp = EmuCore::do_cmp_less_equal<get_left_uq, get_right_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return cmp()
+		(
+			std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_))),
+			std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_)))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Checks if the current state of the passed Rect is well-formed.</para>
+	/// <para> A well-formed Rect will have a Left value less than or equal to its Right value, and a Top value less than or equal to its Bottom value. </para>
+	/// </summary>
+	/// <returns>True if the passed Rect's X- and Y-axes are both well-formed; otherwise false.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_is_well_formed(Rect_&& rect_)
+	{
+		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
+	}
+
+	template<typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_left_uq = typename EmuCore::TMP::remove_ref_cv<get_left_result>::type;
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_top_uq = typename EmuCore::TMP::remove_ref_cv<get_top_result>::type;
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_right_uq = typename EmuCore::TMP::remove_ref_cv<get_right_result>::type;
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+		using get_bottom_uq = typename EmuCore::TMP::remove_ref_cv<get_bottom_result>::type;
+
+		using x_type = typename std::conditional<std::is_lvalue_reference_v<X_>, X_, typename rect_uq::preferred_floating_point>::type;
+		using y_type = typename std::conditional<std::is_lvalue_reference_v<Y_>, Y_, typename rect_uq::preferred_floating_point>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<x_type>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<y_type>::type;
+		x_type x = static_cast<x_type>(std::forward<X_>(x_));
+		y_type y = static_cast<y_type>(std::forward<Y_>(y_));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return
+		(
+			EmuCore::do_cmp_less_equal<get_left_uq, x_uq>()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
+			EmuCore::do_cmp_less_equal<get_top_uq, y_uq>()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
+			EmuCore::do_cmp_greater_equal<get_right_uq, x_uq>()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
+			EmuCore::do_cmp_greater_equal<get_bottom_uq, y_uq>()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
+		);
+#pragma warning(pop)
+	}
+
+	template<EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
+	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return rect_contains_point
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<0>(),
+			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<1>()
+		);
+#pragma warning(pop)
+	}
+
+	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectA_, EmuMath::TMP::EmuRect RectB_>
+	[[nodiscard]] constexpr inline bool rect_colliding_axis_aligned(RectA_&& rect_a_, RectB_&& rect_b_)
+	{
+		using cmp_less = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_less<void, void>, EmuCore::do_cmp_less_equal<void, void>>::type;
+		using cmp_greater = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_greater<void, void>, EmuCore::do_cmp_greater_equal<void, void>>::type;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return
+		(
+			cmp_less()(rect_get_left(std::forward<RectA_>(rect_a_)), rect_get_right(std::forward<RectB_>(rect_b_))) &&
+			cmp_greater()(rect_get_right(std::forward<RectA_>(rect_a_)), rect_get_left(std::forward<RectB_>(rect_b_))) &&
+			cmp_less()(rect_get_top(std::forward<RectA_>(rect_a_)), rect_get_bottom(std::forward<RectB_>(rect_b_))) &&
+			cmp_greater()(rect_get_bottom(std::forward<RectA_>(rect_a_)), rect_get_top(std::forward<RectB_>(rect_b_)))
+		);
+#pragma warning(pop)
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -11,7 +11,7 @@ namespace EmuMath::Helpers
 	/// <para> A well-formed X-axis will have a Left value less than or equal to its Right value. </para>
 	/// </summary>
 	/// <returns>True if the passed Rect's X-axis is well-formed; otherwise false.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_has_well_formed_x(Rect_&& rect_)
 	{
 		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
@@ -35,7 +35,7 @@ namespace EmuMath::Helpers
 	/// <para> A well-formed Y-axis will have a Top value less than or equal to its Bottom value. </para>
 	/// </summary>
 	/// <returns>True if the passed Rect's Y-axis is well-formed; otherwise false.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_has_well_formed_y(Rect_&& rect_)
 	{
 		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
@@ -59,7 +59,7 @@ namespace EmuMath::Helpers
 	/// <para> A well-formed Rect will have a Left value less than or equal to its Right value, and a Top value less than or equal to its Bottom value. </para>
 	/// </summary>
 	/// <returns>True if the passed Rect's X- and Y-axes are both well-formed; otherwise false.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_is_well_formed(Rect_&& rect_)
 	{
 		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
@@ -73,7 +73,7 @@ namespace EmuMath::Helpers
 	/// <param name="x_">X coordinate to check for.</param>
 	/// <param name="y_">Y coordinate to check for.</param>
 	/// <returns>True if the provided X and Y coordinates are contained within the passed Rect's boundaries.</returns>
-	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -116,7 +116,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
 	/// <returns>True if the provided coordinates are contained within the passed Rect's boundaries.</returns>
-	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, EmuConcepts::EmuVector PointVector_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
 	{
 #pragma warning(push)
@@ -138,7 +138,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_a_">First Rect involved in the collision check.</param>
 	/// <param name="rect_b_">Second Rect involved in the collision check.</param>
 	/// <returns>If the two passed Rects are colliding, `true`; otherwise `false`.</returns>
-	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectA_, EmuMath::TMP::EmuRect RectB_>
+	template<bool IgnoreEqual_ = true, EmuConcepts::EmuRect RectA_, EmuConcepts::EmuRect RectB_>
 	[[nodiscard]] constexpr inline bool rect_colliding_axis_aligned(RectA_&& rect_a_, RectB_&& rect_b_)
 	{
 		using cmp_less = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_less<void, void>, EmuCore::do_cmp_less_equal<void, void>>::type;

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -65,7 +65,7 @@ namespace EmuMath::Helpers
 		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
 	}
 
-	template<typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -85,24 +85,27 @@ namespace EmuMath::Helpers
 		x_type x = static_cast<x_type>(std::forward<X_>(x_));
 		y_type y = static_cast<y_type>(std::forward<Y_>(y_));
 
+		using cmp_less = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_less<void, void>, EmuCore::do_cmp_less_equal<void, void>>::type;
+		using cmp_greater = typename std::conditional<IgnoreEqual_, EmuCore::do_cmp_greater<void, void>, EmuCore::do_cmp_greater_equal<void, void>>::type;
+
 #pragma warning(push)
 #pragma warning(disable: 26800)
 		return
 		(
-			EmuCore::do_cmp_less_equal<get_left_uq, x_uq>()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
-			EmuCore::do_cmp_less_equal<get_top_uq, y_uq>()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
-			EmuCore::do_cmp_greater_equal<get_right_uq, x_uq>()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
-			EmuCore::do_cmp_greater_equal<get_bottom_uq, y_uq>()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
+			cmp_less()(rect_get_left(std::forward<Rect_>(rect_)), x) &&
+			cmp_less()(rect_get_top(std::forward<Rect_>(rect_)), y) &&
+			cmp_greater()(rect_get_right(std::forward<Rect_>(rect_)), x) &&
+			cmp_greater()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
 		);
 #pragma warning(pop)
 	}
 
-	template<EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
+	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
 	{
 #pragma warning(push)
 #pragma warning(disable: 26800)
-		return rect_contains_point
+		return rect_contains_point<IgnoreEqual_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<PointVector_>(point_vector_2d_).template AtTheoretical<0>(),

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_checks.h
@@ -65,6 +65,14 @@ namespace EmuMath::Helpers
 		return rect_has_well_formed_x(std::forward<Rect_>(rect_)) && rect_has_well_formed_y(std::forward<Rect_>(rect_));
 	}
 
+	/// <summary>
+	/// <para> Determines if a given point is contained within the passed Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// <para> May customise whether the point is classed as outside if on the boundaries of the Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="x_">X coordinate to check for.</param>
+	/// <param name="y_">Y coordinate to check for.</param>
+	/// <returns>True if the provided X and Y coordinates are contained within the passed Rect's boundaries.</returns>
 	template<bool IgnoreEqual_ = true, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
@@ -100,6 +108,14 @@ namespace EmuMath::Helpers
 #pragma warning(pop)
 	}
 
+
+	/// <summary>
+	/// <para> Determines if a given point is contained within the passed Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// <para> May customise whether the point is classed as outside if on the boundaries of the Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+	/// <returns>True if the provided coordinates are contained within the passed Rect's boundaries.</returns>
 	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline bool rect_contains_point(Rect_&& rect_, PointVector_&& point_vector_2d_)
 	{
@@ -114,6 +130,14 @@ namespace EmuMath::Helpers
 #pragma warning(pop)
 	}
 
+	/// <summary>
+	/// <para> Checks if the two passed Rects are colliding in an axis-aligned context (i.e. they are considered not rotated or warped in any way). </para>
+	/// <para> This assumes that both Rects are well-formed. </para>
+	/// <para> May customise whether a point is classed as outside if on the boundaries of a Rect via IgnoreEqual_. If omitted, this defaults to `true`. </para>
+	/// </summary>
+	/// <param name="rect_a_">First Rect involved in the collision check.</param>
+	/// <param name="rect_b_">Second Rect involved in the collision check.</param>
+	/// <returns>If the two passed Rects are colliding, `true`; otherwise `false`.</returns>
 	template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectA_, EmuMath::TMP::EmuRect RectB_>
 	[[nodiscard]] constexpr inline bool rect_colliding_axis_aligned(RectA_&& rect_a_, RectB_&& rect_b_)
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
@@ -8,7 +8,7 @@ namespace EmuMath::Helpers
 {
 	namespace _rect_underlying
 	{
-		template<std::size_t ForIndex_, std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, EmuMath::TMP::EmuRect Rect_>
+		template<std::size_t ForIndex_, std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, EmuConcepts::EmuRect Rect_>
 		[[nodiscard]] constexpr inline decltype(auto) _get_for_vector_index(Rect_&& rect_)
 		{
 			if constexpr (ForIndex_ == LeftIndex_)
@@ -61,7 +61,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">Rect to convert.</param>
 	/// <returns>Converted form of the input Rect.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_cast(Rect_&& rect_)
 	{
 		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
@@ -87,7 +87,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="out_rect_">EmuMath Rect to assign conversion results to.</param>
 	/// <param name="rect_">Rect to convert.</param>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline void rect_cast(EmuMath::Rect<OutT_>& out_rect_, Rect_&& rect_)
 	{
 		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
@@ -112,7 +112,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">Rect to convert to a Vector.</param>
 	/// <returns>4D EmuMath Vector containing the 4 boundaries of the input Rect in specified indices.</returns>
-	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline auto rect_as_vector(Rect_&& rect_)
 		-> std::enable_if_t<rect_valid_index_args_for_vector_conversion<LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(), EmuMath::Vector<4, OutT_>>
 	{
@@ -128,7 +128,7 @@ namespace EmuMath::Helpers
 #pragma warning(pop)
 	}
 
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> rect_as_vector(Rect_&& rect_)
 	{
 		return rect_as_vector<0, 1, 2, 3>(std::forward<Rect_>(rect_));

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_conversions.h
@@ -1,0 +1,138 @@
+#ifndef EMU_MATH_RECT_CONVERSIONS_H_INC_
+#define EMU_MATH_RECT_CONVERSIONS_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	namespace _rect_underlying
+	{
+		template<std::size_t ForIndex_, std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, EmuMath::TMP::EmuRect Rect_>
+		[[nodiscard]] constexpr inline decltype(auto) _get_for_vector_index(Rect_&& rect_)
+		{
+			if constexpr (ForIndex_ == LeftIndex_)
+			{
+				using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+				return std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == TopIndex_)
+			{
+				using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+				return std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == RightIndex_)
+			{
+				using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+				return std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)));
+			}
+			else if constexpr (ForIndex_ == BottomIndex_)
+			{
+				using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+				return std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_)));
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<ForIndex_>(),
+					"Attempted to convert an EmuMath Rect to an EmuMath Vector, but input index data provided an out-of-range index."
+				);
+			}
+		}
+	}
+
+	/// <summary>
+	/// <para> Checks if the passed indices are valid for creating an EmuMath Vector from a Rect. </para>
+	/// </summary>
+	/// <returns>If all indices are in the inclusive range 0:3 and none are duplicated, returns `true`; otherwise returns `false`.</returns>
+	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_>
+	[[nodiscard]] constexpr inline bool rect_valid_index_args_for_vector_conversion()
+	{
+		return
+		(
+			(LeftIndex_ <= 3 && TopIndex_ <= 3 && RightIndex_ <= 3 && BottomIndex_ <= 3) &&
+			EmuCore::TMP::all_consts_unique<LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>::value
+		);
+	}
+
+	/// <summary>
+	/// <para> Casts the input Rect to an EmuMath Rect of the specified type. </para>
+	/// </summary>
+	/// <param name="rect_">Rect to convert.</param>
+	/// <returns>Converted form of the input Rect.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_cast(Rect_&& rect_)
+	{
+		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return EmuMath::Rect<OutT_>
+		(
+			static_cast<out_value_uq>(std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_top_result>(rect_get_top(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_right_result>(rect_get_right(std::forward<Rect_>(rect_)))),
+			static_cast<out_value_uq>(std::forward<get_bottom_result>(rect_get_bottom(std::forward<Rect_>(rect_))))
+		);
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Casts the input Rect and assigns the results to the passed output Rect. </para>
+	/// </summary>
+	/// <param name="out_rect_">EmuMath Rect to assign conversion results to.</param>
+	/// <param name="rect_">Rect to convert.</param>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline void rect_cast(EmuMath::Rect<OutT_>& out_rect_, Rect_&& rect_)
+	{
+		using out_value_uq = typename EmuMath::Rect<OutT_>::value_type_uq;
+		using get_left_result = decltype(rect_get_left(std::forward<Rect_>(rect_)));
+		using get_top_result = decltype(rect_get_top(std::forward<Rect_>(rect_)));
+		using get_right_result = decltype(rect_get_right(std::forward<Rect_>(rect_)));
+		using get_bottom_result = decltype(rect_get_bottom(std::forward<Rect_>(rect_)));
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_left(out_rect_), std::forward<get_left_result>(rect_get_left(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_top(out_rect_), std::forward<get_left_result>(rect_get_top(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_right(out_rect_), std::forward<get_left_result>(rect_get_right(std::forward<Rect_>(rect_))));
+		EmuCore::TMP::assign_direct_or_cast<out_value_uq>(rect_get_bottom(out_rect_), std::forward<get_left_result>(rect_get_bottom(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
+	}
+
+	/// <summary>
+	/// <para> Converts the input Rect to a 4D Vector of its 4 boundaries as specified. </para>
+	/// <para> Input indices indicate which Vector index to assign the named boundary to. These may only be non-repeating values in the inclusive range 0:3. </para>
+	/// <para> Input indices may be omitted, in which case they will default to 0, 1, 2, 3. </para>
+	/// </summary>
+	/// <param name="rect_">Rect to convert to a Vector.</param>
+	/// <returns>4D EmuMath Vector containing the 4 boundaries of the input Rect in specified indices.</returns>
+	template<std::size_t LeftIndex_, std::size_t TopIndex_, std::size_t RightIndex_, std::size_t BottomIndex_, typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_as_vector(Rect_&& rect_)
+		-> std::enable_if_t<rect_valid_index_args_for_vector_conversion<LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(), EmuMath::Vector<4, OutT_>>
+	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
+		return EmuMath::Vector<4, OutT_>
+		(
+			_rect_underlying::_get_for_vector_index<0, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<1, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<2, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_)),
+			_rect_underlying::_get_for_vector_index<3, LeftIndex_, TopIndex_, RightIndex_, BottomIndex_>(std::forward<Rect_>(rect_))
+		);
+#pragma warning(pop)
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> rect_as_vector(Rect_&& rect_)
+	{
+		return rect_as_vector<0, 1, 2, 3>(std::forward<Rect_>(rect_));
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -136,7 +136,8 @@ namespace EmuMath::Helpers
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
-		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<Out_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, typename rect_uq::preferred_floating_point, float>::type;
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
@@ -164,7 +165,8 @@ namespace EmuMath::Helpers
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
-		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<Out_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, typename rect_uq::preferred_floating_point, float>::type;
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -59,7 +59,11 @@ namespace EmuMath::Helpers
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
 		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return static_cast<OutT_>(sub_func()(rect_get_right(std::forward<Rect_>(rect_)), rect_get_left(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -72,7 +76,11 @@ namespace EmuMath::Helpers
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
 		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return static_cast<OutT_>(sub_func()(rect_get_bottom(std::forward<Rect_>(rect_)), rect_get_top(std::forward<Rect_>(rect_))));
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -86,11 +94,14 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_size(Rect_&& rect_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Vector<2, OutT_>
 		(
 			rect_get_width<OutT_>(std::forward<Rect_>(rect_)),
 			rect_get_height<OutT_>(std::forward<Rect_>(rect_))
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -141,6 +152,9 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp right = static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_)));
 		return static_cast<Out_>
 		(
@@ -154,6 +168,7 @@ namespace EmuMath::Helpers
 				)
 			)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -170,6 +185,8 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp bottom = static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_)));
 		return static_cast<Out_>
 		(
@@ -183,6 +200,7 @@ namespace EmuMath::Helpers
 				)
 			)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -193,11 +211,14 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Vector<2, OutT_>
 		(
 			rect_get_centre_x<OutT_>(std::forward<Rect_>(rect_)),
 			rect_get_centre_y<OutT_>(std::forward<Rect_>(rect_))
 		);
+#pragma warning(pop)
 	}
 }
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -104,18 +104,34 @@ namespace EmuMath::Helpers
 		return EmuMath::Helpers::vector_square_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>The length of the passed Rectangle.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+	/// </summary>
+	/// <returns>The length of the passed Rectangle.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_constexpr(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle in the X-axis. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>Central point of the passed Rectangle in the X-axis.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
 	{
@@ -139,6 +155,11 @@ namespace EmuMath::Helpers
 		);
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle in the Y-axis. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Height` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>Central point of the passed Rectangle in the Y-axis.</returns>
 	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
 	{
@@ -162,6 +183,11 @@ namespace EmuMath::Helpers
 		);
 	}
 
+	/// <summary>
+	/// <para> Calculates the central point of the passed Rectangle, and outputs the X- and Y-axes' points as indices 0 and 1 (respectively) of a 2D Vector. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` and `Height` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>2D EmuMath Vector containing the passed Rect's central X and Y points in indices 0 and 1 respectively.</returns>
 	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -1,0 +1,176 @@
+#ifndef EMU_MATH_RECT_GET_H_INC_
+#define EMU_MATH_RECT_GET_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `left` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the X coordinate of left corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_left(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Left();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `right` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the X coordinate of right corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_right(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Right();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `top` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the Y coordinate of top corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_top(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Top();
+	}
+
+	/// <summary>
+	/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of the passed Rect. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to retrieve to `bottom` value of.</param>
+	/// <returns>Lvalue or Rvalue reference to the Y coordinate of bottom corners in the passed Rect, depending on the qualification of `rect_`.</returns>
+	template<EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline decltype(auto) rect_get_bottom(Rect_&& rect_)
+	{
+		return std::forward<Rect_>(rect_).Bottom();
+	}
+
+	/// <summary>
+	/// <para> Calculates the width of the passed Rect based on the distance between its left and right points. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>The width of the passed Rect, based on `Right - Left`.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline OutT_ rect_get_width(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+		return static_cast<OutT_>(sub_func()(rect_get_right(std::forward<Rect_>(rect_)), rect_get_left(std::forward<Rect_>(rect_))));
+	}
+
+	/// <summary>
+	/// <para> Calculates the height of the passed Rect based on the distance between its top and bottom points. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>The height of the passed Rect, based on `Bottom - Top`.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline OutT_ rect_get_height(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using sub_func = EmuCore::do_subtract<typename rect_uq::value_type_uq, typename rect_uq::value_type_uq>;
+		return static_cast<OutT_>(sub_func()(rect_get_bottom(std::forward<Rect_>(rect_)), rect_get_top(std::forward<Rect_>(rect_))));
+	}
+
+	/// <summary>
+	/// <para>
+	///		Calculates the width of the passed Rect based on the distance between its left and right points, 
+	///		and its height based on the distance between its top and bottom points.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <returns>2D Vector containing the width of the passed Rect in index 0, and its height in index 1.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_size(Rect_&& rect_)
+	{
+		return EmuMath::Vector<2, OutT_>
+		(
+			rect_get_width<OutT_>(std::forward<Rect_>(rect_)),
+			rect_get_height<OutT_>(std::forward<Rect_>(rect_))
+		);
+	}
+
+	/// <summary>
+	/// <para> Calculates the squared length of the passed Rectangle's diagonal. </para>
+	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
+	/// </summary>
+	/// <returns>The squared length of the passed Rectangle.</returns>
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_squared(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_square_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_constexpr(Rect_&& rect_)
+	{
+		return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp right = static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_)));
+		return static_cast<Out_>
+		(
+			sub_func()
+			(
+				right,
+				div_func()
+				(
+					sub_func()(right, static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)))),
+					calc_fp(2)
+				)
+			)
+		);
+	}
+
+	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<Out_, typename rect_uq::preferred_floating_point, float>::type;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp bottom = static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_)));
+		return static_cast<Out_>
+		(
+			sub_func()
+			(
+				bottom,
+				div_func()
+				(
+					sub_func()(bottom, static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)))),
+					calc_fp(2)
+				)
+			)
+		);
+	}
+
+	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
+	{
+		return EmuMath::Vector<2, OutT_>
+		(
+			rect_get_centre_x<OutT_>(std::forward<Rect_>(rect_)),
+			rect_get_centre_y<OutT_>(std::forward<Rect_>(rect_))
+		);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_get.h
@@ -10,7 +10,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">EmuMath Rect to retrieve to `left` value of.</param>
 	/// <returns>Lvalue or Rvalue reference to the X coordinate of left corners in the passed Rect, depending on the qualification of `rect_`.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline decltype(auto) rect_get_left(Rect_&& rect_)
 	{
 		return std::forward<Rect_>(rect_).Left();
@@ -21,7 +21,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">EmuMath Rect to retrieve to `right` value of.</param>
 	/// <returns>Lvalue or Rvalue reference to the X coordinate of right corners in the passed Rect, depending on the qualification of `rect_`.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline decltype(auto) rect_get_right(Rect_&& rect_)
 	{
 		return std::forward<Rect_>(rect_).Right();
@@ -32,7 +32,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">EmuMath Rect to retrieve to `top` value of.</param>
 	/// <returns>Lvalue or Rvalue reference to the Y coordinate of top corners in the passed Rect, depending on the qualification of `rect_`.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline decltype(auto) rect_get_top(Rect_&& rect_)
 	{
 		return std::forward<Rect_>(rect_).Top();
@@ -43,7 +43,7 @@ namespace EmuMath::Helpers
 	/// </summary>
 	/// <param name="rect_">EmuMath Rect to retrieve to `bottom` value of.</param>
 	/// <returns>Lvalue or Rvalue reference to the Y coordinate of bottom corners in the passed Rect, depending on the qualification of `rect_`.</returns>
-	template<EmuMath::TMP::EmuRect Rect_>
+	template<EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline decltype(auto) rect_get_bottom(Rect_&& rect_)
 	{
 		return std::forward<Rect_>(rect_).Bottom();
@@ -54,7 +54,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed. </para>
 	/// </summary>
 	/// <returns>The width of the passed Rect, based on `Right - Left`.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline OutT_ rect_get_width(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -71,7 +71,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed. </para>
 	/// </summary>
 	/// <returns>The height of the passed Rect, based on `Bottom - Top`.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline OutT_ rect_get_height(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -91,7 +91,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed. </para>
 	/// </summary>
 	/// <returns>2D Vector containing the width of the passed Rect in index 0, and its height in index 1.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_size(Rect_&& rect_)
 	{
 #pragma warning(push)
@@ -109,7 +109,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
 	/// </summary>
 	/// <returns>The squared length of the passed Rectangle.</returns>
-	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	template<typename Out_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_squared(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_square_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
@@ -120,7 +120,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of the passed Rectangle. </para>
 	/// </summary>
 	/// <returns>The length of the passed Rectangle.</returns>
-	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	template<typename Out_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
@@ -132,7 +132,7 @@ namespace EmuMath::Helpers
 	/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
 	/// </summary>
 	/// <returns>The length of the passed Rectangle.</returns>
-	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	template<typename Out_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_diagonal_length_constexpr(Rect_&& rect_)
 	{
 		return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(rect_get_size<Out_>(std::forward<Rect_>(rect_)));
@@ -143,7 +143,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` of the passed Rectangle. </para>
 	/// </summary>
 	/// <returns>Central point of the passed Rectangle in the X-axis.</returns>
-	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	template<typename Out_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_x(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -176,7 +176,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed, and is based on the `Height` of the passed Rectangle. </para>
 	/// </summary>
 	/// <returns>Central point of the passed Rectangle in the Y-axis.</returns>
-	template<typename Out_, EmuMath::TMP::EmuRect Rect_>
+	template<typename Out_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline Out_ rect_get_centre_y(Rect_&& rect_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -208,7 +208,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed, and is based on the `Width` and `Height` of the passed Rectangle. </para>
 	/// </summary>
 	/// <returns>2D EmuMath Vector containing the passed Rect's central X and Y points in indices 0 and 1 respectively.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> rect_get_centre(Rect_&& rect_)
 	{
 #pragma warning(push)

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
@@ -1,0 +1,344 @@
+#ifndef EMU_MATH_RECT_MUTATE_H_INC_
+#define EMU_MATH_RECT_MUTATE_H_INC_ 1
+
+#include "_common_rect_helper_includes.h"
+#include "_rect_get.h"
+
+namespace EmuMath::Helpers
+{
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="centre_x_">Point in the X-axis to centre the new Rect on.</param>
+	/// <param name="centre_y_">Point in the Y-axis to centre the new Rect on.</param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, X_&& centre_x_, Y_&& centre_y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp x = static_cast<calc_fp>(std::forward<X_>(centre_x_));
+		calc_fp y = static_cast<calc_fp>(std::forward<Y_>(centre_y_));
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(x, width_div_2),
+			sub_func()(y, height_div_2),
+			add_func()(x, width_div_2),
+			add_func()(y, height_div_2)
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="vector_centre_2d_">
+	///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+	/// </param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuVector CentreVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, CentreVector_&& vector_centre_2d_)
+	{
+		return rect_make_centred<OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<0>(),
+			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates an adjusted form of the passed Rect which is centred on the provided point in both the X- and Y-axes. </para>
+	/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
+	/// <param name="shared_centre_x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+	template<typename OutT_, typename ScalarSharedCentre_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_make_centred(Rect_&& rect_, ScalarSharedCentre_&& shared_centre_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScalarSharedCentre_>, EmuMath::Rect<OutT_>>
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using centre_uq = typename EmuCore::TMP::remove_ref_cv<ScalarSharedCentre_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, centre_uq, out_fp, in_fp>::type;
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
+		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_)); 
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(x_and_y, width_div_2),
+			sub_func()(x_and_y, height_div_2),
+			add_func()(x_and_y, width_div_2),
+			add_func()(x_and_y, height_div_2)
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
+	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
+	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
+	{
+		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+		using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+		using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+		using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+		using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+		using in_fp = typename rect_uq::preferred_floating_point;
+		using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+
+		using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+		using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
+		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+		// Central values start as value in of the boundary in the negative direction
+		calc_fp centre_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
+		calc_fp centre_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
+
+		// Calculate half-sizes manually (in case moves were used above)
+		// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
+		calc_fp half_height = div_func()(sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), centre_y), calc_fp(2));
+		calc_fp half_width = div_func()(sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), centre_x), calc_fp(2));
+
+		// Actually centre these values
+		centre_x = add_func()(centre_x, half_width);
+		centre_y = add_func()(centre_y, half_height);
+
+		// Scale half-sizes and then apply them to the centres to make new boundaries
+		half_height = mul_func()(half_height, static_cast<calc_fp>(std::forward<Y_>(scale_y_)));
+		half_width = mul_func()(half_width, static_cast<calc_fp>(std::forward<X_>(scale_x_)));
+
+		return EmuMath::Rect<OutT_>
+		(
+			sub_func()(centre_x, half_width),
+			sub_func()(centre_y, half_height),
+			add_func()(centre_x, half_width),
+			add_func()(centre_y, half_height)
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
+	/// <returns>The passed Rect scaled by the provided factors in all axes, with the same central point.</returns>
+	template<typename OutT_, EmuMath::TMP::EmuVector ScaleVector_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
+	{
+		return rect_scale<OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para>
+	///		Creates a copy of the passed Rect scaled about its centre, 
+	///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+	/// </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+	template<typename OutT_, typename ScaleScalar_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_scale(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+	{
+		const auto& scale_x_and_y_lval = EmuCore::TMP::const_lval_ref_cast<ScaleScalar_>(std::forward<ScaleScalar_>(scale_x_and_y_));
+		return rect_scale<OutT_>(std::forward<Rect_>(rect_), scale_x_and_y_lval, scale_x_and_y_lval);
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
+	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
+	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
+	{
+		if constexpr (XAnchorDirection_ == 0 && YAnchorDirection_ == 0)
+		{
+			return rect_scale<OutT_>(std::forward<Rect_>(rect_), std::forward<X_>(scale_x_), std::forward<Y_>(scale_y_));
+		}
+		else
+		{
+			using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
+			using out_uq = typename EmuCore::TMP::remove_ref_cv<OutT_>::type;
+			using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
+			using y_uq = typename EmuCore::TMP::remove_ref_cv<Y_>::type;
+			using out_fp = typename EmuMath::Rect<OutT_>::preferred_floating_point;
+			using in_fp = typename rect_uq::preferred_floating_point;
+			using calc_fp = typename EmuCore::TMP::largest_floating_point<out_uq, x_uq, y_uq, out_fp, in_fp>::type;
+
+
+			using add_func = EmuCore::do_add<calc_fp, calc_fp>;
+			using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
+			using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
+			using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
+
+			// Central values start as value of the boundary in the negative direction
+			calc_fp anchored_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
+			calc_fp anchored_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
+
+			// Calculate sizes manually (in case moves were used above)
+			// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
+			// --- Respective sizes will be halved later for anchors in the positive direction
+			calc_fp height = sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), anchored_y);
+			calc_fp width = sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), anchored_x);
+
+			// Actually anchor these values, and update sizes to correctly calculate end results
+			// --- No need to modify if anchor direction is negative, as we are already bound to that anchor with the correct width for calculation
+			if constexpr (XAnchorDirection_ >= 0)
+			{
+				if constexpr (XAnchorDirection_ == 0)
+				{
+					width = div_func()(width, calc_fp(2));
+				}
+				anchored_x = add_func()(anchored_x, width);
+			}
+
+			if constexpr (YAnchorDirection_ >= 0)
+			{
+				if constexpr (YAnchorDirection_ == 0)
+				{
+					height = div_func()(height, calc_fp(2));
+				}
+				anchored_y = add_func()(anchored_y, height);
+			}
+
+			// Scale sizes and then apply them to the centres to make new boundaries
+			height = mul_func()(height, static_cast<calc_fp>(std::forward<Y_>(scale_y_)));
+			width = mul_func()(width, static_cast<calc_fp>(std::forward<X_>(scale_x_)));
+
+			// Declare output boundaries as their anchors
+			calc_fp left = anchored_x;
+			calc_fp top = anchored_y;
+			calc_fp right = anchored_x;
+			calc_fp bottom = anchored_y;
+
+			// Follows the pattern:
+			// --- Negative boundaries need respective size subtracted with non-negative anchors, otherwise ready
+			// --- Positive boundaries need respective size added with centred or negative anchors, otherwise ready
+			if constexpr (XAnchorDirection_ >= 0)
+			{
+				left = sub_func()(left, width);
+			}
+
+			if constexpr (YAnchorDirection_ >= 0)
+			{
+				top = sub_func()(top, height);
+			}
+
+			if constexpr (XAnchorDirection_ <= 0)
+			{
+				right = add_func()(right, width);
+			}
+
+			if constexpr (YAnchorDirection_ <= 0)
+			{
+				bottom = add_func()(bottom, height);
+			}
+
+			return EmuMath::Rect<OutT_>
+			(
+				std::move(left),
+				std::move(top),
+				std::move(right),
+				std::move(bottom)
+			);
+		}
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuMath::TMP::EmuVector ScaleVector_,  EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
+	{
+		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
+		(
+			std::forward<Rect_>(rect_),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
+			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
+		);
+	}
+
+	/// <summary>
+	/// <para> Creates a copy of the passed Rect scaled about the specified anchor. </para>
+	/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+	/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+	/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+	/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+	/// <para> This assumes that the Rect is well-formed. </para>
+	/// </summary>
+	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
+	/// <returns>The passed Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename ScaleScalar_,  EmuMath::TMP::EmuRect Rect_>
+	[[nodiscard]] constexpr inline auto rect_scale_anchored(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+	{
+		const auto& scale_x_and_y_lval = EmuCore::TMP::const_lval_ref_cast<ScaleScalar_>(std::forward<ScaleScalar_>(scale_x_and_y_));
+		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(std::forward<Rect_>(rect_), scale_x_and_y_lval, scale_x_and_y_lval);
+	}
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
@@ -34,6 +34,8 @@ namespace EmuMath::Helpers
 		calc_fp x = static_cast<calc_fp>(std::forward<X_>(centre_x_));
 		calc_fp y = static_cast<calc_fp>(std::forward<Y_>(centre_y_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Rect<OutT_>
 		(
 			sub_func()(x, width_div_2),
@@ -41,6 +43,7 @@ namespace EmuMath::Helpers
 			add_func()(x, width_div_2),
 			add_func()(y, height_div_2)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -55,12 +58,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector CentreVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, CentreVector_&& vector_centre_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_make_centred<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<0>(),
 			std::forward<CentreVector_>(vector_centre_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -85,9 +91,12 @@ namespace EmuMath::Helpers
 		using sub_func = EmuCore::do_subtract<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		calc_fp width_div_2 = div_func()(rect_get_width<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
 		calc_fp height_div_2 = div_func()(rect_get_height<calc_fp>(std::forward<Rect_>(rect_)), calc_fp(2));
-		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_)); 
+		calc_fp x_and_y = static_cast<calc_fp>(std::forward<ScalarSharedCentre_>(shared_centre_x_and_y_));
+#pragma warning(pop)
 
 		return EmuMath::Rect<OutT_>
 		(
@@ -126,6 +135,8 @@ namespace EmuMath::Helpers
 		using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
 		using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		// Central values start as value in of the boundary in the negative direction
 		calc_fp centre_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
 		calc_fp centre_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
@@ -134,6 +145,7 @@ namespace EmuMath::Helpers
 		// --- Reminder: centre_x and centre_y are actually the negative-direction boundaries at this stage, so this is (bottom - top) and (right - left)
 		calc_fp half_height = div_func()(sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), centre_y), calc_fp(2));
 		calc_fp half_width = div_func()(sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), centre_x), calc_fp(2));
+#pragma warning(pop)
 
 		// Actually centre these values
 		centre_x = add_func()(centre_x, half_width);
@@ -165,12 +177,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector ScaleVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_scale<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -226,6 +241,8 @@ namespace EmuMath::Helpers
 			using mul_func = EmuCore::do_multiply<calc_fp, calc_fp>;
 			using div_func = EmuCore::do_divide<calc_fp, calc_fp>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 			// Central values start as value of the boundary in the negative direction
 			calc_fp anchored_x = static_cast<calc_fp>(rect_get_left(std::forward<Rect_>(rect_)));
 			calc_fp anchored_y = static_cast<calc_fp>(rect_get_top(std::forward<Rect_>(rect_)));
@@ -235,6 +252,7 @@ namespace EmuMath::Helpers
 			// --- Respective sizes will be halved later for anchors in the positive direction
 			calc_fp height = sub_func()(static_cast<calc_fp>(rect_get_bottom(std::forward<Rect_>(rect_))), anchored_y);
 			calc_fp width = sub_func()(static_cast<calc_fp>(rect_get_right(std::forward<Rect_>(rect_))), anchored_x);
+#pragma warning(pop)
 
 			// Actually anchor these values, and update sizes to correctly calculate end results
 			// --- No need to modify if anchor direction is negative, as we are already bound to that anchor with the correct width for calculation
@@ -313,12 +331,15 @@ namespace EmuMath::Helpers
 	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuMath::TMP::EmuVector ScaleVector_,  EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<0>(),
 			std::forward<ScaleVector_>(scale_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -368,6 +389,8 @@ namespace EmuMath::Helpers
 		calc_type x = static_cast<calc_type>(std::forward<X_>(x_));
 		calc_type y = static_cast<calc_type>(std::forward<Y_>(y_));
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return EmuMath::Rect<OutT_>
 		(
 			add_func()(rect_get_left(std::forward<Rect_>(rect_)), x),
@@ -375,6 +398,7 @@ namespace EmuMath::Helpers
 			add_func()(rect_get_right(std::forward<Rect_>(rect_)), x),
 			add_func()(rect_get_bottom(std::forward<Rect_>(rect_)), y)
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -388,12 +412,15 @@ namespace EmuMath::Helpers
 	template<typename OutT_, EmuMath::TMP::EmuVector TranslationVector_, EmuMath::TMP::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_translate(Rect_&& rect_, TranslationVector_&& translation_vector_2d_)
 	{
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		return rect_translate<OutT_>
 		(
 			std::forward<Rect_>(rect_),
 			std::forward<TranslationVector_>(translation_vector_2d_).template AtTheoretical<0>(),
 			std::forward<TranslationVector_>(translation_vector_2d_).template AtTheoretical<1>()
 		);
+#pragma warning(pop)
 	}
 
 	/// <summary>
@@ -412,10 +439,13 @@ namespace EmuMath::Helpers
 		using add_func = EmuCore::do_add<in_value_uq, in_value_uq>;
 		using sub_func = EmuCore::do_subtract<in_value_uq, in_value_uq>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		in_value_uq left = rect_get_left(std::forward<Rect_>(rect_));
 		in_value_uq top = rect_get_top(std::forward<Rect_>(rect_));
 		in_value_uq right = rect_get_right(std::forward<Rect_>(rect_));
 		in_value_uq bottom = rect_get_bottom(std::forward<Rect_>(rect_));
+#pragma warning(pop)
 
 		// If a direction is 0, there is no reflection in that axis and thus boundaries remain the same
 		// --- If reflecting in negative direction, negative boundary has size subtracted and positive boundary becomes old negative boundary
@@ -477,10 +507,13 @@ namespace EmuMath::Helpers
 		using add_func = EmuCore::do_add<in_value_uq, in_value_uq>;
 		using sub_func = EmuCore::do_subtract<in_value_uq, in_value_uq>;
 
+#pragma warning(push)
+#pragma warning(disable: 26800)
 		in_value_uq left = rect_get_left(std::forward<Rect_>(rect_));
 		in_value_uq top = rect_get_top(std::forward<Rect_>(rect_));
 		in_value_uq right = rect_get_right(std::forward<Rect_>(rect_));
 		in_value_uq bottom = rect_get_bottom(std::forward<Rect_>(rect_));
+#pragma warning(pop)
 
 		// If a direction is 0, there is no reflection in that axis and thus boundaries remain the same
 		// --- If reflecting in negative direction, negative boundary has size subtracted and positive boundary becomes old negative boundary

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_helpers/_rect_mutate.h
@@ -14,7 +14,7 @@ namespace EmuMath::Helpers
 	/// <param name="centre_x_">Point in the X-axis to centre the new Rect on.</param>
 	/// <param name="centre_y_">Point in the Y-axis to centre the new Rect on.</param>
 	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, typename X_, typename Y_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, X_&& centre_x_, Y_&& centre_y_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -55,7 +55,7 @@ namespace EmuMath::Helpers
 	///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
 	/// </param>
 	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuVector CentreVector_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuVector CentreVector_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_make_centred(Rect_&& rect_, CentreVector_&& vector_centre_2d_)
 	{
 #pragma warning(push)
@@ -76,7 +76,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_">EmuMath Rect to create a centred form of.</param>
 	/// <param name="shared_centre_x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
 	/// <returns>Copy of the passed Rect adjusted to be centred on the provided coordinate in both axes.</returns>
-	template<typename OutT_, typename ScalarSharedCentre_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, typename ScalarSharedCentre_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline auto rect_make_centred(Rect_&& rect_, ScalarSharedCentre_&& shared_centre_x_and_y_)
 		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScalarSharedCentre_>, EmuMath::Rect<OutT_>>
 	{
@@ -118,7 +118,7 @@ namespace EmuMath::Helpers
 	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
 	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
 	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, typename X_, typename Y_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
 	{
 		using rect_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -174,7 +174,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
 	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
 	/// <returns>The passed Rect scaled by the provided factors in all axes, with the same central point.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuVector ScaleVector_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuVector ScaleVector_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
 #pragma warning(push)
@@ -198,7 +198,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
 	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 	/// <returns>The passed Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-	template<typename OutT_, typename ScaleScalar_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, typename ScaleScalar_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline auto rect_scale(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
 		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
 	{
@@ -218,7 +218,7 @@ namespace EmuMath::Helpers
 	/// <param name="scale_x_">Scale to apply to the passed Rect's width.</param>
 	/// <param name="scale_y_">Scale to apply to the passed Rect's height.</param>
 	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
-	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename X_, typename Y_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, X_&& scale_x_, Y_&& scale_y_)
 	{
 		if constexpr (XAnchorDirection_ == 0 && YAnchorDirection_ == 0)
@@ -328,7 +328,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
 	/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 	/// <returns>The passed Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
-	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuMath::TMP::EmuVector ScaleVector_,  EmuMath::TMP::EmuRect Rect_>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, EmuConcepts::EmuVector ScaleVector_,  EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_scale_anchored(Rect_&& rect_, ScaleVector_&& scale_vector_2d_)
 	{
 #pragma warning(push)
@@ -353,7 +353,7 @@ namespace EmuMath::Helpers
 	/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
 	/// <param name="scale_x_and_y_">Scale to apply to the passed Rect's width and height.</param>
 	/// <returns>The passed Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
-	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename ScaleScalar_,  EmuMath::TMP::EmuRect Rect_>
+	template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_, typename ScaleScalar_,  EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline auto rect_scale_anchored(Rect_&& rect_, ScaleScalar_&& scale_x_and_y_)
 		-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
 	{
@@ -368,7 +368,7 @@ namespace EmuMath::Helpers
 	/// <param name="x_">Amount to move the passed Rectangle by in the X-axis.</param>
 	/// <param name="y_">Amount to move the passed Rectangle by in the Y-axis.</param>
 	/// <returns>The passed Rect translated by the specified amounts in respective axes.</returns>
-	template<typename OutT_, typename X_, typename Y_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, typename X_, typename Y_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_translate(Rect_&& rect_, X_&& x_, Y_&& y_)
 	{
 		using x_uq = typename EmuCore::TMP::remove_ref_cv<X_>::type;
@@ -409,7 +409,7 @@ namespace EmuMath::Helpers
 	///		EmuMath Vector of translations to apply to the passed Rect, with X and Y at theoretical indices 0 and 1 respectively.
 	/// </param>
 	/// <returns>The passed Rect translated by the specified amounts in respective axes.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuVector TranslationVector_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuVector TranslationVector_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_translate(Rect_&& rect_, TranslationVector_&& translation_vector_2d_)
 	{
 #pragma warning(push)
@@ -430,7 +430,7 @@ namespace EmuMath::Helpers
 	/// <para> This assumes that the Rect is well-formed. </para>
 	/// </summary>
 	/// <returns>The passed Rect reflected as specified by the passed template arguments.</returns>
-	template<signed int XDirection_, signed int YDirection_, typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<signed int XDirection_, signed int YDirection_, typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_reflect(Rect_&& rect_)
 	{
 		using in_uq = typename EmuCore::TMP::remove_ref_cv<Rect_>::type;
@@ -497,7 +497,7 @@ namespace EmuMath::Helpers
 	/// <param name="x_direction_">0: No X-axis reflection; Positive: Reflect against Right boundary; Negative: Reflect against Left boundary.</param>
 	/// <param name="y_direction_">0: No Y-axis reflection; Positive: Reflect against Bottom boundary; Negative: Reflect against Top boundary.</param>
 	/// <returns>The passed Rect reflected as specified by the passed arguments.</returns>
-	template<typename OutT_, EmuMath::TMP::EmuRect Rect_>
+	template<typename OutT_, EmuConcepts::EmuRect Rect_>
 	[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> rect_reflect(Rect_&& rect_, signed int x_direction_, signed int y_direction_)
 	{
 		// Identical to above version, but runtime conditional branches

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -216,7 +216,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		template<typename OutT_ = preferred_floating_point, EmuConcepts::EmuVector ScaleVector_>
 		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> operator*(ScaleVector_&& scale_vector_2d_) const
 		{
 			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
@@ -252,7 +252,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<EmuMath::TMP::EmuVector ScaleVector_>
+		template<EmuConcepts::EmuVector ScaleVector_>
 		constexpr inline this_type& operator*=(ScaleVector_&& scale_vector_2d_)
 		{
 			return this->operator=(EmuMath::Helpers::rect_scale<value_type_uq>(*this, std::forward<ScaleVector_>(scale_vector_2d_)));
@@ -508,7 +508,7 @@ namespace EmuMath
 		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
 		/// </param>
 		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector CentreVector_>
+		template<typename OutT_ = preferred_floating_point, EmuConcepts::EmuVector CentreVector_>
 		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(CentreVector_&& x_and_y_vector_) const
 		{
 			return EmuMath::Helpers::rect_make_centred<OutT_>(*this, std::forward<CentreVector_>(x_and_y_vector_));
@@ -555,7 +555,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		template<typename OutT_ = preferred_floating_point, EmuConcepts::EmuVector ScaleVector_>
 		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(ScaleVector_&& scale_vector_2d_) const
 		{
 			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
@@ -613,7 +613,7 @@ namespace EmuMath
 		/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
 		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
 		/// <returns>This Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
-		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, EmuConcepts::EmuVector ScaleVector_>
 		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> ScaleAnchored(ScaleVector_&& scale_vector_2d_) const
 		{
 			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
@@ -658,7 +658,7 @@ namespace EmuMath
 		///		EmuMath Vector of translations to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.
 		/// </param>
 		/// <returns>This Rect translated by the specified amounts in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector TranslationVector_>
+		template<typename OutT_ = preferred_floating_point, EmuConcepts::EmuVector TranslationVector_>
 		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Translate(TranslationVector_&& translation_vector_2d_) const
 		{
 			return EmuMath::Helpers::rect_translate<OutT_>(*this, std::forward<TranslationVector_>(translation_vector_2d_));
@@ -717,7 +717,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
 		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
-		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_>
+		template<bool IgnoreEqual_ = true, EmuConcepts::EmuVector PointVector_>
 		[[nodiscard]] constexpr inline bool ContainsPoint(PointVector_&& point_vector_2d_) const
 		{
 			return EmuMath::Helpers::rect_contains_point<IgnoreEqual_>(*this, std::forward<PointVector_>(point_vector_2d_));
@@ -733,7 +733,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="rect_b_">Second Rect involved in the collision check.</param>
 		/// <returns>If the this Rect and the passed Rect are colliding, `true`; otherwise `false`.</returns>
-		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectB_>
+		template<bool IgnoreEqual_ = true, EmuConcepts::EmuRect RectB_>
 		[[nodiscard]] constexpr inline bool CollidingAxisAligned(RectB_&& rect_b_) const
 		{
 			return EmuMath::Helpers::rect_colliding_axis_aligned<IgnoreEqual_>(*this, std::forward<RectB_>(rect_b_));

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -773,10 +773,10 @@ namespace EmuMath
 		/// <param name="x_">X coordinate to check for.</param>
 		/// <param name="y_">Y coordinate to check for.</param>
 		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
-		template<typename X_, typename Y_>
+		template<bool IgnoreEqual_ = true, typename X_, typename Y_>
 		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
 		{
-			return EmuMath::Helpers::rect_contains_point(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
+			return EmuMath::Helpers::rect_contains_point<IgnoreEqual_>(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
 		}
 
 		/// <summary>
@@ -785,10 +785,10 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
 		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
-		template<EmuMath::TMP::EmuVector PointVector_>
+		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuVector PointVector_>
 		[[nodiscard]] constexpr inline bool ContainsPoint(PointVector_&& point_vector_2d_) const
 		{
-			return EmuMath::Helpers::rect_contains_point(*this, std::forward<PointVector_>(point_vector_2d_));
+			return EmuMath::Helpers::rect_contains_point<IgnoreEqual_>(*this, std::forward<PointVector_>(point_vector_2d_));
 		}
 
 		template<bool IgnoreEqual_ = true, EmuMath::TMP::EmuRect RectB_>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -116,6 +116,20 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region CONST_ARITHMETIC_OPERATORS
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> operator*(const preferred_floating_point& rhs_scale_) const
+		{
+			return Scale<OutT_>(rhs_scale_, rhs_scale_);
+		}
+
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> operator*(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		{
+			return Scale<OutT_>(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
 #pragma region ACCESSORS
 	private:
 		template<std::size_t Index_, std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
@@ -535,6 +549,79 @@ namespace EmuMath
 		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
 		{
 			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
+#pragma region CONST_ARITHMETIC_FUNCS
+	public:
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
+		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& scale_x_, const preferred_floating_point& scale_y_) const
+		{
+			using add_func = EmuCore::do_add<preferred_floating_point, preferred_floating_point>;
+			using sub_func = EmuCore::do_subtract<preferred_floating_point, preferred_floating_point>;
+			using mul_func = EmuCore::do_multiply<preferred_floating_point, preferred_floating_point>;
+			using div_func = EmuCore::do_divide<preferred_floating_point, preferred_floating_point>;
+
+			preferred_floating_point width = Width<preferred_floating_point>();
+			preferred_floating_point height = Height<preferred_floating_point>();
+
+			preferred_floating_point centre_y = add_func()(Top(), div_func()(height, preferred_floating_point(2)));
+			preferred_floating_point centre_x = add_func()(Left(), div_func()(width, preferred_floating_point(2)));
+
+			// Set width and height to half of new width and height; these are subtracted/added from centres to form begin/end boundaries
+			width = div_func()(mul_func()(width, scale_x_), preferred_floating_point(2));
+			height = div_func()(mul_func()(height, scale_y_), preferred_floating_point(2));
+
+			return EmuMath::Rect<OutT_>
+			(
+				sub_func()(centre_x, width),
+				sub_func()(centre_y, height),
+				add_func()(centre_x, width),
+				add_func()(centre_y, height)
+			);
+		}
+
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="shared_scale_">Scale to apply to this Rect's width and height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& shared_scale_) const
+		{
+			return Scale(shared_scale_, shared_scale_);
+		}
+
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y and theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		{
+			return Scale(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
 		}
 #pragma endregion
 

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_RECT_T_H_INC_
 #define EMU_MATH_RECT_T_H_INC_ 1
 
+#include "_helpers/_all_rect_helpers.h"
 #include "../../Vector.h"
 
 namespace EmuMath
@@ -133,6 +134,15 @@ namespace EmuMath
 
 #pragma region ASSIGNMENT_FUNCS
 	public:
+		/// <summary>
+		/// <para> Sets this Rectangle's boundaries to the respective passed values. </para>
+		/// <para> If `left_` is greater than `right_`, or `top_` is greater than `bottom_`, this makes the Rect ill-formed. </para>
+		/// <para> Rectangles exist in a space where the origin point (0, 0) is in the top-left corner. </para>
+		/// </summary>
+		/// <param name="left_">X-coordinate of the leftmost boundary of the Rectangle.</param>
+		/// <param name="top_">Y-coordinate of the topmost boundary of the Rectangle.</param>
+		/// <param name="right_">X-coordinate of the rightmost boundary of the Rectangle.</param>
+		/// <param name="bottom_">Y-coordinate of the bottommost boundary of the Rectangle.</param>
 		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
 		constexpr inline void Set(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
 		{
@@ -282,26 +292,31 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the X coordinate of left corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Left()
+		[[nodiscard]] constexpr inline value_type& Left() &
 		{
 			return _left_top_right_bottom.template at<_left_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Left() const
+		[[nodiscard]] constexpr inline const value_type& Left() const&
 		{
 			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		[[nodiscard]] constexpr inline value_type&& Left() &&
+		{
+			return std::move(_left_top_right_bottom.template at<_left_index>());
 		}
 
 		/// <summary>
 		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the X coordinate of right corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Right()
+		[[nodiscard]] constexpr inline value_type& Right() &
 		{
 			return _left_top_right_bottom.template at<_right_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Right() const
+		[[nodiscard]] constexpr inline const value_type& Right() const&
 		{
 			return _left_top_right_bottom.template at<_right_index>();
 		}
@@ -310,12 +325,12 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the Y coordinate of top corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Top()
+		[[nodiscard]] constexpr inline value_type& Top() &
 		{
 			return _left_top_right_bottom.template at<_top_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Top() const
+		[[nodiscard]] constexpr inline const value_type& Top() const&
 		{
 			return _left_top_right_bottom.template at<_top_index>();
 		}
@@ -324,12 +339,12 @@ namespace EmuMath
 		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of this Rectangle. </para>
 		/// </summary>
 		/// <returns>Reference to the Y coordinate of bottom corners in this Rectangle.</returns>
-		[[nodiscard]] constexpr inline value_type& Bottom()
+		[[nodiscard]] constexpr inline value_type& Bottom() &
 		{
 			return _left_top_right_bottom.template at<_bottom_index>();
 		}
 
-		[[nodiscard]] constexpr inline const value_type& Bottom() const
+		[[nodiscard]] constexpr inline const value_type& Bottom() const&
 		{
 			return _left_top_right_bottom.template at<_bottom_index>();
 		}
@@ -343,7 +358,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ Width() const
 		{
-			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Right(), Left()));
+			return EmuMath::Helpers::rect_get_width<Out_>(*this);
 		}
 
 		/// <summary>
@@ -355,7 +370,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ Height() const
 		{
-			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Bottom(), Top()));
+			return EmuMath::Helpers::rect_get_height<Out_>(*this);
 		}
 
 		/// <summary>
@@ -368,7 +383,7 @@ namespace EmuMath
 		template<typename OutT_ = value_type_uq>
 		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Size() const
 		{
-			return EmuMath::Vector<2, OutT_>(Width(), Height());
+			return EmuMath::Helpers::rect_get_size<OutT_>(*this);
 		}
 
 		/// <summary>
@@ -380,7 +395,7 @@ namespace EmuMath
 		template<typename Out_ = value_type_uq>
 		[[nodiscard]] constexpr inline Out_ DiagonalSquaredLength() const
 		{
-			return EmuMath::Helpers::vector_square_magnitude<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length_squared<Out_>(*this);
 		}
 
 		/// <summary>
@@ -393,7 +408,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ DiagonalLengthConstexpr() const
 		{
-			return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length_constexpr<Out_>(*this);
 		}
 
 		/// <summary>
@@ -405,7 +420,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ DiagonalLength() const
 		{
-			return EmuMath::Helpers::vector_magnitude<Out_>(Size<Out_>());
+			return EmuMath::Helpers::rect_get_diagonal_length<Out_>(*this);
 		}
 
 		/// <summary>
@@ -417,11 +432,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ CentralX() const
 		{
-			return EmuCore::do_add<Out_, Out_>()
-			(
-				static_cast<Out_>(Left()),
-				EmuCore::do_divide<Out_, Out_>()(Width<Out_>(), Out_(2))
-			);
+			return EmuMath::Helpers::rect_get_centre_x<Out_>(*this);
 		}
 
 		/// <summary>
@@ -433,11 +444,7 @@ namespace EmuMath
 		template<typename Out_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline Out_ CentralY() const
 		{
-			return EmuCore::do_add<Out_, Out_>()
-			(
-				static_cast<Out_>(Top()),
-				EmuCore::do_divide<Out_, Out_>()(Height<Out_>(), Out_(2))
-			);
+			return EmuMath::Helpers::rect_get_centre_y<Out_>(*this);
 		}
 
 		/// <summary>
@@ -449,7 +456,7 @@ namespace EmuMath
 		template<typename OutT_ = preferred_floating_point>
 		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Centre() const
 		{
-			return EmuMath::Vector<2, OutT_>(CentralX<OutT_>(), CentralY<OutT_>());
+			return EmuMath::Helpers::rect_get_centre<OutT_>(*this);
 		}
 
 		/// <summary>

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -502,6 +502,42 @@ namespace EmuMath
 		}
 #pragma endregion
 
+#pragma region CONTAINS_CHECKS
+	public:
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="x_">X coordinate to check for.</param>
+		/// <param name="y_">Y coordinate to check for.</param>
+		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
+		template<typename X_, typename Y_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
+		{
+			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
+			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
+			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
+			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
+			return
+			(
+				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
+				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
+			);
+		}
+
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
+		template<std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
+		{
+			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
 	private:
 		_underlying_vector _left_top_right_bottom;
 	};

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -545,107 +545,6 @@ namespace EmuMath
 #pragma endregion
 
 #pragma region MUTATIONS
-	public:
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
-		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
-		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
-		{
-			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
-			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
-			OutT_ x = static_cast<OutT_>(std::forward<X_>(x_));
-			OutT_ y = static_cast<OutT_>(std::forward<Y_>(y_));
-			return Rect<OutT_>
-			(
-				EmuCore::do_subtract<OutT_, OutT_>()(x, width_div_2),
-				EmuCore::do_subtract<OutT_, OutT_>()(y, height_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x, width_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(y, height_div_2)
-			);
-		}
-
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_and_y_vector_">
-		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
-		/// </param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
-		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(const EmuMath::Vector<VecSize_, VecT_>& x_and_y_vector_) const
-		{
-			return MakeCentred(x_and_y_vector_.template AtTheoretical<0>(), x_and_y_vector_.template AtTheoretical<1>());
-		}
-
-		/// <summary>
-		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
-		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
-		/// </summary>
-		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
-		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
-		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
-		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
-			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
-		{
-			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
-			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
-			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
-			return Rect<OutT_>
-			(
-				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
-				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
-				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
-			);
-		}
-#pragma endregion
-
-#pragma region CONTAINS_CHECKS
-	public:
-		/// <summary>
-		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
-		/// <para> This assumes that the Rect is well-formed. </para>
-		/// </summary>
-		/// <param name="x_">X coordinate to check for.</param>
-		/// <param name="y_">Y coordinate to check for.</param>
-		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
-		template<typename X_, typename Y_>
-		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
-		{
-			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
-			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
-			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
-			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
-			return
-			(
-				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
-				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
-			);
-		}
-
-		/// <summary>
-		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
-		/// <para> This assumes that the Rect is well-formed. </para>
-		/// </summary>
-		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
-		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
-		template<std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
-		{
-			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
-		}
-#pragma endregion
-
-#pragma region CONST_ARITHMETIC_FUNCS
 	private:
 		template<std::int32_t Direction_>
 		[[nodiscard]] constexpr inline decltype(auto) _get_reflected_left() const
@@ -755,41 +654,88 @@ namespace EmuMath
 
 	public:
 		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
+		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
+		{
+			return EmuMath::Helpers::rect_make_centred<OutT_>(*this, std::forward<X_>(x_), std::forward<Y_>(y_));
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_vector_">
+		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+		/// </param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector CentreVector_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(CentreVector_&& x_and_y_vector_) const
+		{
+			return EmuMath::Helpers::rect_make_centred<OutT_>(*this, std::forward<CentreVector_>(x_and_y_vector_));
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
+		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
+			);
+		}
+		
+		/// <summary>
 		/// <para>
 		///		Creates a copy of this Rect scaled about its centre, 
 		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
 		/// </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
 		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
 		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
 		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& scale_x_, const preferred_floating_point& scale_y_) const
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(X_&& scale_x_, Y_&& scale_y_) const
 		{
-			using add_func = EmuCore::do_add<preferred_floating_point, preferred_floating_point>;
-			using sub_func = EmuCore::do_subtract<preferred_floating_point, preferred_floating_point>;
-			using mul_func = EmuCore::do_multiply<preferred_floating_point, preferred_floating_point>;
-			using div_func = EmuCore::do_divide<preferred_floating_point, preferred_floating_point>;
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<X_>(scale_x_), std::forward<Y_>(scale_y_));
+		}
 
-			preferred_floating_point width = Width<preferred_floating_point>();
-			preferred_floating_point height = Height<preferred_floating_point>();
-
-			preferred_floating_point centre_y = add_func()(Top(), div_func()(height, preferred_floating_point(2)));
-			preferred_floating_point centre_x = add_func()(Left(), div_func()(width, preferred_floating_point(2)));
-
-			// Set width and height to half of new width and height; these are subtracted/added from centres to form begin/end boundaries
-			width = div_func()(mul_func()(width, scale_x_), preferred_floating_point(2));
-			height = div_func()(mul_func()(height, scale_y_), preferred_floating_point(2));
-
-			return EmuMath::Rect<OutT_>
-			(
-				sub_func()(centre_x, width),
-				sub_func()(centre_y, height),
-				add_func()(centre_x, width),
-				add_func()(centre_y, height)
-			);
+		/// <summary>
+		/// <para>
+		///		Creates a copy of this Rect scaled about its centre, 
+		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
+		/// </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
+		template<typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(ScaleVector_&& scale_vector_2d_) const
+		{
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
 		}
 
 		/// <summary>
@@ -798,30 +744,74 @@ namespace EmuMath
 		///		changing all boundaries to scale its size in all axes whilst maintaining the same central point.
 		/// </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
-		/// <param name="shared_scale_">Scale to apply to this Rect's width and height.</param>
+		/// <param name="scale_x_and_y_">Scale to apply to this Rect's width and height.</param>
 		/// <returns>This Rect scaled by the provided factor in all axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const preferred_floating_point& shared_scale_) const
+		template<typename OutT_ = preferred_floating_point, typename ScaleScalar_>
+		[[nodiscard]] constexpr inline auto Scale(ScaleScalar_&& scale_x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
 		{
-			return Scale(shared_scale_, shared_scale_);
+			return EmuMath::Helpers::rect_scale<OutT_>(*this, std::forward<ScaleScalar_>(scale_x_and_y_));
 		}
 
 		/// <summary>
-		/// <para>
-		///		Creates a copy of this Rect scaled about its centre, 
-		///		changing all boundaries to scale its size in respective axes whilst maintaining the same central point.
-		/// </para>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
 		/// <para> This assumes that the Rect is well-formed. </para>
-		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
 		/// </summary>
-		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
-		/// <returns>This Rect scaled by the provided factors in respective axes, with the same central point.</returns>
-		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
-		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> Scale(const EmuMath::Vector<VecSize_, VecT_>& scale_vector_2d_) const
+		/// <param name="scale_x_">Scale to apply to this Rect's width.</param>
+		/// <param name="scale_y_">Scale to apply to this Rect's height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> ScaleAnchored(X_&& scale_x_, Y_&& scale_y_) const
 		{
-			return Scale(scale_vector_2d_.template AtTheoretical<0>(), scale_vector_2d_.template AtTheoretical<1>());
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>
+			(
+				*this,
+				std::forward<X_>(scale_x_),
+				std::forward<Y_>(scale_y_)
+			);
+		}
+
+		/// <summary>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="rect_">EmuMath Rect to create a scaled form of.</param>
+		/// <param name="scale_vector_2d_">EmuMath Vector of scales to apply to this Rect, with X and Y at theoretical indices 0 and 1 respectively.</param>
+		/// <returns>This Rect scaled by the provided factor in respective axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, EmuMath::TMP::EmuVector ScaleVector_>
+		[[nodiscard]] constexpr inline EmuMath::Rect<OutT_> ScaleAnchored(ScaleVector_&& scale_vector_2d_) const
+		{
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(*this, std::forward<ScaleVector_>(scale_vector_2d_));
+		}
+
+		/// <summary>
+		/// <para> Creates a copy of this Rect scaled about the specified anchor. </para>
+		/// <para> XAnchorDirection_: 0: Centre of the X-axis; Negative: Left boundary of the X-axis; Positive non-0: Right boundary of the X-axis. </para>
+		/// <para> YAnchorDirection_: 0: Centre of the Y-axis; Negative: Top boundary of the Y-axis; Positive non-0: Bottom boundary of the Y-axis. </para>
+		/// <para> When anchored to a boundary, that boundary will not be modified and the opposite boundary will receive the full effect of the scale. </para>
+		/// <para> When anchored to a central point, both of that axis's boundaries scaled by half the amount to maintain the same central point. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="scale_x_and_y_">Scale to apply to this Rect's width and height.</param>
+		/// <returns>This Rect scaled by the provided factor in all axes, with points of specified anchors maintained as the same value.</returns>
+		template<signed int XAnchorDirection_, signed int YAnchorDirection_, typename OutT_ = preferred_floating_point, typename ScaleScalar_>
+		[[nodiscard]] constexpr inline auto ScaleAnchored(ScaleScalar_&& scale_x_and_y_)
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<ScaleScalar_>, EmuMath::Rect<OutT_>>
+		{
+			return EmuMath::Helpers::rect_scale_anchored<XAnchorDirection_, YAnchorDirection_, OutT_>(*this, std::forward<ScaleScalar_>(scale_x_and_y_));
 		}
 
 		/// <summary>
@@ -898,6 +888,45 @@ namespace EmuMath
 				std::move(get<1>(top_bottom))
 			);
 		}
+#pragma endregion
+
+#pragma region CONTAINS_CHECKS
+	public:
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="x_">X coordinate to check for.</param>
+		/// <param name="y_">Y coordinate to check for.</param>
+		/// <returns>True if the provided X and Y coordinates are contained within this Rect's boundaries.</returns>
+		template<typename X_, typename Y_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(X_&& x_, Y_&& y_) const
+		{
+			using cmp_less_equal = EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>;
+			using cmp_greater_equal = EmuCore::do_cmp_greater_equal<value_type_uq, value_type_uq>;
+			value_type_uq x = static_cast<value_type_uq>(std::forward<X_>(x_));
+			value_type_uq y = static_cast<value_type_uq>(std::forward<Y_>(y_));
+			return
+			(
+				(cmp_less_equal()(Top(), y) && cmp_greater_equal()(Bottom(), y)) &&
+				(cmp_less_equal()(Left(), x) && cmp_greater_equal()(Right(), x))
+			);
+		}
+
+		/// <summary>
+		/// <para> Determines if a given point is contained within this Rect based on its current Left, Top, Right, and Bottom boundaries </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// </summary>
+		/// <param name="point_vec_2d_">EmuMath Vector with coordinates to search for in the X- and Y-axes in theoretical indices 0 and 1 respectively..</param>
+		/// <returns>True if the provided coordinates are contained within this Rect's boundaries.</returns>
+		template<std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline bool ContainsPoint(const EmuMath::Vector<VecSize_, VecT_>& point_vec_2d_) const
+		{
+			return ContainsPoint(point_vec_2d_.template AtTheoretical<0>(), point_vec_2d_.template AtTheoretical<1>());
+		}
+#pragma endregion
+
+#pragma region CONST_ARITHMETIC_FUNCS
 #pragma endregion
 
 	private:

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -71,7 +71,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="size_">Size of the square to create the Rect as.</param>
 		template<typename Size_>
-		constexpr inline Rect(Size_&& size_) :
+		explicit constexpr inline Rect(Size_&& size_) :
 			_left_top_right_bottom(_make_data(std::forward<Size_>(size_)))
 		{
 		}
@@ -105,7 +105,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_copy_">Rect of a different type to copy/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(const EmuMath::Rect<ToCopyT_>& to_copy_) :
+		explicit constexpr inline Rect(const EmuMath::Rect<ToCopyT_>& to_copy_) :
 			_left_top_right_bottom(_make_data(to_copy_.Left(), to_copy_.Top(), to_copy_.Right(), to_copy_.Bottom()))
 		{
 		}
@@ -115,7 +115,7 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_copy_">Rect of a different type to copy/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(EmuMath::Rect<ToCopyT_>& to_copy_) :
+		explicit constexpr inline Rect(EmuMath::Rect<ToCopyT_>& to_copy_) :
 			_left_top_right_bottom(_make_data(to_copy_.Left(), to_copy_.Top(), to_copy_.Right(), to_copy_.Bottom()))
 		{
 		}
@@ -125,9 +125,21 @@ namespace EmuMath
 		/// </summary>
 		/// <param name="to_move_">Rect of a different type to move/convert.</param>
 		template<typename ToCopyT_, typename = std::enable_if_t<!std::is_same_v<T_, ToCopyT_>>>
-		constexpr inline Rect(EmuMath::Rect<ToCopyT_>&& to_move_) :
+		explicit constexpr inline Rect(EmuMath::Rect<ToCopyT_>&& to_move_) :
 			_left_top_right_bottom(_make_data(std::move(to_move_.Left()), std::move(to_move_.Top()), std::move(to_move_.Right()), std::move(to_move_.Bottom())))
 		{
+		}
+#pragma endregion
+
+#pragma region ASSIGNMENT_FUNCS
+	public:
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		constexpr inline void Set(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
+		{
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Left(), std::forward<Left_>(left_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Top(), std::forward<Top_>(top_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Right(), std::forward<Right_>(right_));
+			EmuCore::TMP::assign_direct_or_cast<value_type_uq>(Bottom(), std::forward<Bottom_>(bottom_));
 		}
 #pragma endregion
 
@@ -139,9 +151,37 @@ namespace EmuMath
 			return *this;
 		}
 
+		constexpr inline this_type& operator=(Rect<T_>& to_copy_)
+		{
+			_left_top_right_bottom = to_copy_._left_top_right_bottom;
+			return *this;
+		}
+
 		constexpr inline this_type& operator=(Rect<T_>&& to_move_) noexcept
 		{
 			_left_top_right_bottom = std::move(to_move_._left_top_right_bottom);
+			return *this;
+		}
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(const Rect<RhsT_>& rhs_)
+		{
+			Set(rhs_.Left(), rhs_.Top(), rhs_.Right(), rhs_.Bottom());
+			return *this;
+		}
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(Rect<RhsT_>& rhs_)
+		{
+			Set(rhs_.Left(), rhs_.Top(), rhs_.Right(), rhs_.Bottom());
+			return *this;
+		}
+
+
+		template<typename RhsT_>
+		constexpr inline this_type& operator=(Rect<RhsT_>&& rhs_)
+		{
+			Set(std::move(rhs_.Left()), std::move(rhs_.Top()), std::move(rhs_.Right()), std::move(rhs_.Bottom()));
 			return *this;
 		}
 #pragma endregion

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_rect_t.h
@@ -1,0 +1,510 @@
+#ifndef EMU_MATH_RECT_T_H_INC_
+#define EMU_MATH_RECT_T_H_INC_ 1
+
+#include "../../Vector.h"
+
+namespace EmuMath
+{
+	/// <summary>
+	/// <para> Type used to store and retrieve basic information regarding a rectangle, with the origin point (0, 0) at a theoretical top-left. </para>
+	/// </summary>
+	template<typename T_>
+	struct Rect
+	{
+	private:
+		using _underlying_vector = EmuMath::Vector<4, T_>;
+		static constexpr std::size_t _left_index = 0;
+		static constexpr std::size_t _top_index = 1;
+		static constexpr std::size_t _right_index = 2;
+		static constexpr std::size_t _bottom_index = 3;
+
+	public:
+		using this_type = Rect<T_>;
+		using stored_type = typename _underlying_vector::stored_type;
+		using value_type = typename _underlying_vector::value_type;
+		using value_type_uq = typename _underlying_vector::value_type_uq;
+		using preferred_floating_point = typename _underlying_vector::preferred_floating_point;
+
+		[[nodiscard]] static constexpr inline value_type_uq get_implied_zero()
+		{
+			return _underlying_vector::get_implied_zero();
+		}
+
+	private:
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_)
+		{
+			return _underlying_vector(std::forward<Left_>(left_), std::forward<Top_>(top_), std::forward<Right_>(right_), std::forward<Bottom_>(bottom_));
+		}
+
+		template<typename Width_, typename Height_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Width_&& width_, Height_&& height_)
+		{
+			return _underlying_vector(get_implied_zero(), get_implied_zero(), std::forward<Width_>(width_), std::forward<Height_>(height_));
+		}
+
+		template<typename Size_>
+		[[nodiscard]] static constexpr inline _underlying_vector _make_data(Size_&& size_)
+		{
+			auto& size = EmuCore::TMP::lval_ref_cast<Size_>(std::forward<Size_>(size_));
+			return _underlying_vector(get_implied_zero(), get_implied_zero(), static_cast<value_type>(size), static_cast<value_type>(size));
+		}
+
+#pragma region CONSTRUCTORS
+	public:
+		constexpr inline Rect() : _left_top_right_bottom()
+		{
+		}
+
+		constexpr inline Rect(const Rect& to_copy_) :
+			_left_top_right_bottom(to_copy_._left_top_right_bottom)
+		{
+		}
+
+		constexpr inline Rect(Rect&& to_move_) noexcept : 
+			_left_top_right_bottom(std::move(to_move_._left_top_right_bottom))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect as a square of the specified size, with its top-left corner at point (0, 0). </para>
+		/// </summary>
+		/// <param name="size_">Size of the square to create the Rect as.</param>
+		template<typename Size_>
+		constexpr inline Rect(Size_&& size_) :
+			_left_top_right_bottom(_make_data(std::forward<Size_>(size_)))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect of the specified size, with its top-left corner at the point (0, 0). </para>
+		/// </summary>
+		/// <param name="width_">Size of the Rect in the X-axis.</param>
+		/// <param name="height_">Size of the Rect in the Y-axis.</param>
+		template<typename Width_, typename Height_>
+		constexpr inline Rect(Width_&& width_, Height_&& height_) : 
+			_left_top_right_bottom(_make_data(std::forward<Width_>(width_), std::forward<Height_>(height_)))
+		{
+		}
+
+		/// <summary>
+		/// <para> Creates a Rect with the axes of its borders defined by the respective passed values. </para>
+		/// </summary>
+		/// <param name="left_">X-coordinate of the Rect's left boundary. This should be the smallest value in the X-axis to be considered well-formed.</param>
+		/// <param name="top_">Y-coordinate of the Rect's top boundary. This should be the smallest value in the Y-axis to be considered well-formed.</param>
+		/// <param name="right_">X-coordinate of the Rect's right boundary. This should be the highest value in the X-axis to be considered well-formed.</param>
+		/// <param name="bottom_">Y-coordinate of the Rect's bottom boundary. This should be the highest value in the Y-axis to be considered well-formed.</param>
+		template<typename Left_, typename Top_, typename Right_, typename Bottom_>
+		constexpr inline Rect(Left_&& left_, Top_&& top_, Right_&& right_, Bottom_&& bottom_) :
+			_left_top_right_bottom(_make_data(std::forward<Left_>(left_), std::forward<Top_>(top_), std::forward<Right_>(right_), std::forward<Bottom_>(bottom_)))
+		{
+		}
+#pragma endregion
+
+#pragma region ASSIGNMENT_OPERATORS
+	public:
+		constexpr inline this_type& operator=(const Rect<T_>& to_copy_)
+		{
+			_left_top_right_bottom = to_copy_._left_top_right_bottom;
+			return *this;
+		}
+
+		constexpr inline this_type& operator=(Rect<T_>&& to_move_) noexcept
+		{
+			_left_top_right_bottom = std::move(to_move_._left_top_right_bottom);
+			return *this;
+		}
+#pragma endregion
+
+#pragma region ACCESSORS
+	private:
+		template<std::size_t Index_, std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
+		[[nodiscard]] constexpr inline decltype(auto) _get_item_for_vector()
+		{
+			if constexpr (Index_ == Left_)
+			{
+				return Left();
+			}
+			else if constexpr (Index_ == Top_)
+			{
+				return Top();
+			}
+			else if constexpr (Index_ == Right_)
+			{
+				return Right();
+			}
+			else if constexpr (Index_ == Bottom_)
+			{
+				return Bottom();
+			}
+			else
+			{
+				static_assert
+				(
+					EmuCore::TMP::get_false<Left_>(),
+					"Failed to shuffle an EmuMath Rect into a 4D EmuMath Vector: At least one of the provided directional indices is invalid."
+				);
+			}
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_>
+		[[nodiscard]] static constexpr inline bool _valid_convert_to_vector_indices()
+		{
+			return
+			(
+				(Left_ != 0 && Top_ != 0 && Right_ != 0 && Bottom_ != 0) &&
+				(Left_ >= 0 && Left_ <= 3 && Top_ >= 0 && Top_ <= 3 && Right_ >= 0 && Right_ <= 3 && Bottom_ >= 0 && Bottom_ <= 3)
+			);
+		}
+
+	public:
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] static constexpr inline bool can_convert_to_vector()
+		{
+			return
+			(
+				_valid_convert_to_vector_indices<Left_, Top_, Right_, Bottom_>() &&
+				std::is_constructible_v<EmuMath::Vector<4, OutT_>, value_type&, value_type&, value_type&, value_type&>
+			);
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] static constexpr inline bool can_const_convert_to_vector()
+		{
+			return
+			(
+				_valid_convert_to_vector_indices<Left_, Top_, Right_, Bottom_>() &&
+				std::is_constructible_v<EmuMath::Vector<4, OutT_>, const value_type&, const value_type&, const value_type&, const value_type&>
+			);
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the left of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the X coordinate of left corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Left()
+		{
+			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Left() const
+		{
+			return _left_top_right_bottom.template at<_left_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the X coordinate of corners on the right of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the X coordinate of right corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Right()
+		{
+			return _left_top_right_bottom.template at<_right_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Right() const
+		{
+			return _left_top_right_bottom.template at<_right_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the top of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the Y coordinate of top corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Top()
+		{
+			return _left_top_right_bottom.template at<_top_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Top() const
+		{
+			return _left_top_right_bottom.template at<_top_index>();
+		}
+
+		/// <summary>
+		/// <para> Retrieves a reference to the value indicating the Y coordinate of corners on the bottom of this Rectangle. </para>
+		/// </summary>
+		/// <returns>Reference to the Y coordinate of bottom corners in this Rectangle.</returns>
+		[[nodiscard]] constexpr inline value_type& Bottom()
+		{
+			return _left_top_right_bottom.template at<_bottom_index>();
+		}
+
+		[[nodiscard]] constexpr inline const value_type& Bottom() const
+		{
+			return _left_top_right_bottom.template at<_bottom_index>();
+		}
+
+		/// <summary>
+		/// <para> Calculates the width of this Rectangle based on the distance between its left and right points. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width of this Rectangle, based on `Right - Left`.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ Width() const
+		{
+			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Right(), Left()));
+		}
+
+		/// <summary>
+		/// <para> Calculates the height of this Rectangle based on the distance between its top and bottom points. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width of this Rectangle, based on `Bottom - Top`.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ Height() const
+		{
+			return static_cast<Out_>(EmuCore::do_subtract<value_type_uq, value_type_uq>()(Bottom(), Top()));
+		}
+
+		/// <summary>
+		/// <para> Calculates the size of this Rectangle in both axes and outputs the results as a 2D Vector. </para>
+		/// <para> The width (X) will be stored in index 0; the height (Y) will be stored in index 1. </para>
+		/// <para> This assumes that the Rect is well-formed. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The width and height of this Rectangle, based on `Right - Left` and `Bottom - Top` respectively.</returns>
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Size() const
+		{
+			return EmuMath::Vector<2, OutT_>(Width(), Height());
+		}
+
+		/// <summary>
+		/// <para> Calculates the squared length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// </summary>
+		/// <returns>The squared length of this Rectangle.</returns>
+		template<typename Out_ = value_type_uq>
+		[[nodiscard]] constexpr inline Out_ DiagonalSquaredLength() const
+		{
+			return EmuMath::Helpers::vector_square_magnitude<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// <para> Calculation will aim to be constexpr-evaluable if possible, which may affect accuracy and/or performance. </para>
+		/// </summary>
+		/// <returns>The length of this Rectangle.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ DiagonalLengthConstexpr() const
+		{
+			return EmuMath::Helpers::vector_magnitude_constexpr<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the length of this Rectangle's diagonal. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Size` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>The length of this Rectangle.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ DiagonalLength() const
+		{
+			return EmuMath::Helpers::vector_magnitude<Out_>(Size<Out_>());
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle in the X-axis. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Width` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>Central point of this Rectangle in the X-axis.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ CentralX() const
+		{
+			return EmuCore::do_add<Out_, Out_>()
+			(
+				static_cast<Out_>(Left()),
+				EmuCore::do_divide<Out_, Out_>()(Width<Out_>(), Out_(2))
+			);
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle in the Y-axis. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Height` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>Central point of this Rectangle in the Y-axis.</returns>
+		template<typename Out_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline Out_ CentralY() const
+		{
+			return EmuCore::do_add<Out_, Out_>()
+			(
+				static_cast<Out_>(Top()),
+				EmuCore::do_divide<Out_, Out_>()(Height<Out_>(), Out_(2))
+			);
+		}
+
+		/// <summary>
+		/// <para> Calculates the central point of this Rectangle, and outputs the X- and Y-axes' points as indices 0 and 1 (respectively) of a 2D Vector. </para>
+		/// <para> This assumes that the Rect is well-formed, and is based on the `Width` and `Height` of this Rectangle. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <returns>2D EmuMath Vector containing this Rect's central X and Y points in indices 0 and 1 respectively.</returns>
+		template<typename OutT_ = preferred_floating_point>
+		[[nodiscard]] constexpr inline EmuMath::Vector<2, OutT_> Centre() const
+		{
+			return EmuMath::Vector<2, OutT_>(CentralX<OutT_>(), CentralY<OutT_>());
+		}
+
+		/// <summary>
+		/// <para> Outputs a 4D Vector containing this Rect's Left, Top, Right, and Bottom values in indices 0, 1, 2, and 3 respectively. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> This function supports output of references. </para>
+		/// </summary>
+		/// <returns>4D EmuMath Vector containing this Rect's Left, Top, Right, and Bottom values in indices 0, 1, 2, and 3 respectively.</returns>
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> AsVector()
+		{
+			return EmuMath::Vector<4, OutT_>(Left(), Top(), Right(), Bottom());
+		}
+
+		template<typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline EmuMath::Vector<4, OutT_> AsVector() const
+		{
+			return EmuMath::Vector<4, OutT_>(Left(), Top(), Right(), Bottom());
+		}
+
+		/// <summary>
+		/// <para> Outputs a 4D Vector containing this Rect's Left, Top, Right, and Bottom values in the respective specified indices. </para>
+		/// <para> The valid inclusive index range is 0:3, and the same index may not be repeated. Specified indices relate to the output Vector. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `value_type_uq`. </para>
+		/// <para> This function supports output of references. </para>
+		/// </summary>
+		/// <returns>4D EmuMath Vector containing this Rect's Left, Top, Right, and Bottom values in the respective specified indices..</returns>
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline auto AsVector()
+			-> std::enable_if_t<can_convert_to_vector<Left_, Top_, Right_, Bottom_, OutT_>(), EmuMath::Vector<4, OutT_>>
+		{
+			return EmuMath::Vector<4, OutT_>
+			(
+				_get_item_for_vector<0, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<1, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<2, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<3, Left_, Top_, Right_, Bottom_>()
+			);
+		}
+
+		template<std::size_t Left_, std::size_t Top_, std::size_t Right_, std::size_t Bottom_, typename OutT_ = value_type_uq>
+		[[nodiscard]] constexpr inline auto AsVector() const
+			-> std::enable_if_t<can_const_convert_to_vector<Left_, Top_, Right_, Bottom_, OutT_>(), EmuMath::Vector<4, OutT_>>
+		{
+			return EmuMath::Vector<4, OutT_>
+			(
+				_get_item_for_vector<0, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<1, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<2, Left_, Top_, Right_, Bottom_>(),
+				_get_item_for_vector<3, Left_, Top_, Right_, Bottom_>()
+			);
+		}
+#pragma endregion
+
+#pragma region VALIDITY_CHECKS
+	public:
+		/// <summary>
+		/// <para> Checks if the current state of this Rect has a well-formed X axis. </para>
+		/// <para> A well-formed X-axis will have a Left value less than or equal to its Right value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's X-axis is well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormedX() const
+		{
+			return EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>()(Left(), Right());
+		}
+
+		/// <summary>
+		/// <para> Checks if the current state of this Rect has a well-formed Y axis. </para>
+		/// <para> A well-formed Y-axis will have a Top value less than or equal to its Bottom value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's Y-axis is well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormedY() const
+		{
+			return EmuCore::do_cmp_less_equal<value_type_uq, value_type_uq>()(Top(), Bottom());
+		}
+
+		/// <summary>
+		/// <para> Checks if the current state of this Rect is well-formed.</para>
+		/// <para> A well-formed Rect will have a Left value less than or equal to its Right value, and a Top value less than or equal to its Bottom value. </para>
+		/// </summary>
+		/// <returns>True if this Rect's X- and Y-axes are both well-formed; otherwise false.</returns>
+		[[nodiscard]] constexpr inline bool WellFormed() const
+		{
+			return WellFormedX() && WellFormedY();
+		}
+#pragma endregion
+
+#pragma region MUTATIONS
+	public:
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_">Point in the X-axis to centre the new Rect on.</param>
+		/// <param name="y_">Point in the Y-axis to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename X_, typename Y_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(X_&& x_, Y_&& y_) const
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x = static_cast<OutT_>(std::forward<X_>(x_));
+			OutT_ y = static_cast<OutT_>(std::forward<Y_>(y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(y, height_div_2)
+			);
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided points in the X- and Y-axes respectively. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_vector_">
+		///		EmuMath Vector containing the points to centre the new Rect on in the X- and Y-axes in theoretical indices 0 and 1, respectively.
+		/// </param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinates in respective axes.</returns>
+		template<typename OutT_ = preferred_floating_point, std::size_t VecSize_, typename VecT_>
+		[[nodiscard]] constexpr inline Rect<OutT_> MakeCentred(const EmuMath::Vector<VecSize_, VecT_>& x_and_y_vector_) const
+		{
+			return MakeCentred(x_and_y_vector_.template AtTheoretical<0>(), x_and_y_vector_.template AtTheoretical<1>());
+		}
+
+		/// <summary>
+		/// <para> Creates an adjusted form of this Rect which is centred on the provided point in both the X- and Y-axes. </para>
+		/// <para> One should be wary of potential inaccuracies when outputting integral types. This issue can be avoided by outputting floating-point types. </para>
+		/// <para> The output type may be customised, but if omitted will default to this Rect's `preferred_floating_point`. </para>
+		/// </summary>
+		/// <param name="x_and_y_">Scalar point in both the X- and Y-axes to centre the new Rect on.</param>
+		/// <returns>Copy of this Rect adjusted to be centred on the provided coordinate in both axes.</returns>
+		template<typename OutT_ = preferred_floating_point, typename SharedPoint_>
+		[[nodiscard]] constexpr inline auto MakeCentred(SharedPoint_&& x_and_y_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_vector_v<typename EmuCore::TMP::remove_ref_cv<SharedPoint_>::type>, Rect<OutT_>>
+		{
+			OutT_ width_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Width<OutT_>(), OutT_(2));
+			OutT_ height_div_2 = EmuCore::do_divide<OutT_, OutT_>()(Height<OutT_>(), OutT_(2));
+			OutT_ x_and_y = static_cast<OutT_>(std::forward<SharedPoint_>(x_and_y_));
+			return Rect<OutT_>
+			(
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_subtract<OutT_, OutT_>()(x_and_y, height_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, width_div_2),
+				EmuCore::do_add<OutT_, OutT_>()(x_and_y, height_div_2)
+			);
+		}
+#pragma endregion
+
+	private:
+		_underlying_vector _left_top_right_bottom;
+	};
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
@@ -1,6 +1,7 @@
 #ifndef EMU_MATH_RECT_TMP_H_IN_
 #define EMU_MATH_RECT_TMP_H_IN_ 1
 
+#include "../../__common/_common_math_tmp.h"
 #include "../../../Vector.h"
 
 namespace EmuMath
@@ -12,31 +13,10 @@ namespace EmuMath
 namespace EmuMath::TMP
 {
 	template<typename T_>
-	struct is_emu_rect
-	{
-	private:
-		using _t_uq = typename EmuCore::TMP::remove_ref_cv<T_>::type;
-
-	public:
-		static constexpr bool value = std::conditional_t
-		<
-			std::is_same_v<T_, _t_uq>,
-			std::false_type,
-			is_emu_rect<_t_uq>
-		>::value;
-	};
-
-	template<typename T_>
-	struct is_emu_rect<Rect<T_>>
+	struct is_emu_rect<EmuMath::Rect<T_>>
 	{
 		static constexpr bool value = true;
 	};
-
-	template<typename T_>
-	static constexpr bool is_emu_rect_v = is_emu_rect<T_>::value;
-
-	template<typename T_>
-	concept EmuRect = is_emu_rect_v<T_>;
 }
 
 #endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_rect/_underlying_helpers/_rect_tmp.h
@@ -1,0 +1,42 @@
+#ifndef EMU_MATH_RECT_TMP_H_IN_
+#define EMU_MATH_RECT_TMP_H_IN_ 1
+
+#include "../../../Vector.h"
+
+namespace EmuMath
+{
+	template<typename T_>
+	struct Rect;
+}
+
+namespace EmuMath::TMP
+{
+	template<typename T_>
+	struct is_emu_rect
+	{
+	private:
+		using _t_uq = typename EmuCore::TMP::remove_ref_cv<T_>::type;
+
+	public:
+		static constexpr bool value = std::conditional_t
+		<
+			std::is_same_v<T_, _t_uq>,
+			std::false_type,
+			is_emu_rect<_t_uq>
+		>::value;
+	};
+
+	template<typename T_>
+	struct is_emu_rect<Rect<T_>>
+	{
+		static constexpr bool value = true;
+	};
+
+	template<typename T_>
+	static constexpr bool is_emu_rect_v = is_emu_rect<T_>::value;
+
+	template<typename T_>
+	concept EmuRect = is_emu_rect_v<T_>;
+}
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_helpers/_vector_basic_arithmetic.h
@@ -426,31 +426,33 @@ namespace EmuMath::Helpers
 	/// <param name="rhs_">: Scalar or EmuMath Vector appearing on the right-hand side of multiplication.</param>
 	/// <returns>EmuMath Vector of the desired OutSize_ (defaults to LhsSize_) and OutT_ (defaults to vector_lhs_'s value_type_uq), containing multiplication results.</returns>
 	template<std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> vector_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+	[[nodiscard]] constexpr inline auto vector_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<OutSize_, OutT_>>
 	{
 		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_multiply, OutSize_, OutT_)(vector_lhs_, std::forward<Rhs_>(rhs_));
 	}
 	template<typename OutT_, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<LhsSize_, OutT_> vector_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+	[[nodiscard]] constexpr inline auto vector_multiply(const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<LhsSize_, OutT_>>
 	{
 		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_multiply, LhsSize_, OutT_)(vector_lhs_, std::forward<Rhs_>(rhs_));
 	}
 	template<std::size_t OutSize_, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq> vector_multiply
+	[[nodiscard]] constexpr inline auto vector_multiply
 	(
 		const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_,
 		Rhs_&& rhs_
-	)
+	) -> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>>
 	{
 		using lhs_value_uq = typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq;
 		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_multiply, OutSize_, lhs_value_uq)(vector_lhs_, std::forward<Rhs_>(rhs_));
 	}
 	template<typename Rhs_, typename LhsT_, std::size_t LhsSize_>
-	[[nodiscard]] constexpr inline EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq> vector_multiply
+	[[nodiscard]] constexpr inline auto vector_multiply
 	(
 		const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_,
 		Rhs_&& rhs_
-	)
+	) -> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>>
 	{
 		using lhs_value_uq = typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq;
 		return EMU_MATH_VECTOR_MUTATE_TEMPLATE(EmuCore::do_multiply, LhsSize_, lhs_value_uq)(vector_lhs_, std::forward<Rhs_>(rhs_));
@@ -458,13 +460,17 @@ namespace EmuMath::Helpers
 
 	/// <summary>
 	/// <para> Outputs the results of multiplying vector_lhs_ by rhs_ to the provided out_vector_. </para>
-	/// <para> If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be multiplied. Otherwise, all elements in vector_lhs_ will be multiplied by rhs_. </para>
+	/// <para>
+	///		If Rhs_ is an EmuMath Vector: Respective elements in each Vector will be multiplied. 
+	///		Otherwise, all elements in vector_lhs_ will be multiplied by rhs_.
+	/// </para>
 	/// </summary>
 	/// <param name="out_vector_">: EmuMath Vector to output to.</param>
 	/// <param name="vector_lhs_">: EmuMath Vector appearing on the left-hand side of multiplication.</param>
 	/// <param name="rhs_">: Scalar or EmuMath Vector appearing on the right-hand side of multiplication.</param>
 	template<std::size_t OutSize_, typename OutT_, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
-	constexpr inline void vector_multiply(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+	constexpr inline auto vector_multiply(EmuMath::Vector<OutSize_, OutT_>& out_vector_, const EmuMath::Vector<LhsSize_, LhsT_>& vector_lhs_, Rhs_&& rhs_)
+		-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, void>
 	{
 		return EMU_MATH_VECTOR_MUTATE_REF_TEMPLATE(EmuCore::do_multiply, OutSize_, OutT_)(out_vector_, vector_lhs_, std::forward<Rhs_>(rhs_));
 	}

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
@@ -2,6 +2,7 @@
 #define EMU_MATH_VECTOR_TMP_H_INC_ 1
 
 #include <cstddef>
+#include "../../__common/_common_math_tmp.h"
 #include "../../../../EmuCore/CommonTypes/DeferrableReferenceWrapper.h"
 #include "../../../../EmuCore/TMPHelpers/StdFeatureChecks.h"
 #include "../../../../EmuCore/TMPHelpers/TypeComparators.h"
@@ -151,26 +152,11 @@ namespace EmuMath
 
 namespace EmuMath::TMP
 {
-	template<class T_>
-	struct is_emu_vector
-	{
-		static constexpr bool value = std::conditional_t
-		<
-			std::is_same_v<T_, EmuCore::TMP::remove_ref_cv_t<T_>>,
-			std::false_type,
-			is_emu_vector<EmuCore::TMP::remove_ref_cv_t<T_>>
-		>::value;
-	};
 	template<std::size_t Size_, typename T_>
 	struct is_emu_vector<EmuMath::Vector<Size_, T_>>
 	{
 		static constexpr bool value = true;
 	};
-	template<class T_>
-	static constexpr bool is_emu_vector_v = is_emu_vector<T_>::value;
-
-	template<typename T_>
-	concept EmuVector = is_emu_vector_v<T_>;
 
 	template<std::size_t Index_, class T_>
 	struct emu_vector_theoretical_return

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
@@ -28,7 +28,7 @@ namespace EmuMath
 	/// <param name="to_ref_">: Reference to wrap as a vector_internal_ref.</param>
 	/// <returns>Passed reference to_ref_ wrapped as a vector_internal_ref of the related type.</returns>
 	template
-		<
+	<
 		typename TypeToReference_,
 		typename = std::enable_if_t
 		<

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_underlying_helpers/_vector_tmp.h
@@ -169,6 +169,9 @@ namespace EmuMath::TMP
 	template<class T_>
 	static constexpr bool is_emu_vector_v = is_emu_vector<T_>::value;
 
+	template<typename T_>
+	concept EmuVector = is_emu_vector_v<T_>;
+
 	template<std::size_t Index_, class T_>
 	struct emu_vector_theoretical_return
 	{

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_operators.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_operators.h
@@ -1,0 +1,768 @@
+#ifndef EMU_MATH_VECTOR_OPERATORS_H_INC_
+#define EMU_MATH_VECTOR_OPERATORS_H_INC_ 1
+
+#include "_vector_t.h"
+
+#pragma region CONST_ARITHMETIC_VALIDITY_CHECKS
+namespace EmuMath::Helpers
+{
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_add_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_subtract_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_multiply_default_operator_args()
+	{
+		return !EmuMath::TMP::is_emu_matrix_v<Rhs_>;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_divide_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_mod_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t Size_, typename T_>
+	[[nodiscard]] constexpr inline bool vector_valid_negate_default_operator_arg()
+	{
+		return true;
+	}
+
+	template<std::size_t Size_, typename T_>
+	[[nodiscard]] constexpr inline bool vector_valid_pre_increment_default_operator_arg()
+	{
+		return true;
+	}
+
+	template<std::size_t Size_, typename T_>
+	[[nodiscard]] constexpr inline bool vector_valid_post_increment_default_operator_arg()
+	{
+		return true;
+	}
+
+	template<std::size_t Size_, typename T_>
+	[[nodiscard]] constexpr inline bool vector_valid_pre_decrement_default_operator_arg()
+	{
+		return true;
+	}
+
+	template<std::size_t Size_, typename T_>
+	[[nodiscard]] constexpr inline bool vector_valid_post_decrement_default_operator_arg()
+	{
+		return true;
+	}
+}
+#pragma endregion
+
+#pragma region CONST_ARITHMETIC
+/// <summary>
+/// <para> Default addition operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of addition.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_add`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_add` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator+(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_add_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_add<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default subtraction operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of subtraction.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_subtract`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_subtract` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator-(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_subtract_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_subtract<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default negation operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="vector_">EmuMath Vector to negate.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_subtract` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_>
+[[nodiscard]] constexpr inline auto operator-(const EmuMath::Vector<LhsSize_, LhsT_>& vector_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_negate_default_operator_arg<LhsSize_, LhsT_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_negate<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(vector_);
+}
+
+/// <summary>
+/// <para> Default multiplication operator for EmuMath Vectors. </para>
+/// <para> Does not accept items identified as an EmuMatrix; such a default implementation is deferred to an extension included by the Matrix module. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of multiplication.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_multiply`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_multiply` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator*(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_multiply_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_multiply<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default division operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of division.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_divide`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_divide` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator/(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_divide_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_divide<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default modulo division operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of modulo division.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_mod`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_mod` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator%(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_mod_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_mod<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+#pragma endregion
+
+#pragma region ARITHMETIC_ASSIGN_VALIDITY_CHECKS
+namespace EmuMath::Helpers
+{
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_add_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_add_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_subtract_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_subtract_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_multiply_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_multiply_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_divide_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_divide_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_mod_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_mod_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+}
+#pragma endregion
+
+#pragma region ARITHMETIC_ASSIGN
+/// <summary>
+/// <para> Default addition-assign operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of addition, and to which respective results will be assigned.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_add_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator+=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_add_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_add_assign(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default subtraction-assign operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of subtraction, and to which respective results will be assigned.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_subtract_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator-=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_subtract_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_subtract_assign(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default multiplication-assign operator for EmuMath Vectors. </para>
+/// <para> Does not accept items identified as an EmuMatrix; such a default implementation is deferred to an extension included by the Matrix module. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of multiplication, and to which respective results will be assigned.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_multiply_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator*=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_multiply_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_multiply_assign(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default division-assign operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of division, and to which respective results will be assigned.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_divide_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator/=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_divide_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_divide_assign(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default modulo division-assign operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of modulo division, and to which respective results will be assigned.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_mod_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator%=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_mod_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_mod_assign(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default pre-increment operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="vector_">EmuMath Vector to perform the pre-increment operation on as per `EmuMath::Helpers::vector_pre_increment`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t Size_, typename T_>
+[[nodiscard]] constexpr inline auto operator++(EmuMath::Vector<Size_, T_>& vector_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_pre_increment_default_operator_arg<Size_, T_>(),
+		EmuMath::Vector<Size_, T_>&
+	>
+{
+	return EmuMath::Helpers::vector_pre_increment(vector_);
+}
+
+/// <summary>
+/// <para> Default post-increment operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="vector_">EmuMath Vector to perform the post-increment operation on as per `EmuMath::Helpers::vector_post_increment`.</param>
+/// <returns>Copy to the left-hand Vector before the increment operation was performed.</returns>
+template<std::size_t Size_, typename T_>
+[[nodiscard]] constexpr inline auto operator++(EmuMath::Vector<Size_, T_>& vector_, int)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_post_increment_default_operator_arg<Size_, T_>(),
+		EmuMath::Vector<Size_, T_>
+	>
+{
+	return EmuMath::Helpers::vector_post_increment(vector_);
+}
+
+/// <summary>
+/// <para> Default pre-decrement operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="vector_">EmuMath Vector to perform the pre-decrement operation on as per `EmuMath::Helpers::vector_pre_decrement`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t Size_, typename T_>
+[[nodiscard]] constexpr inline auto operator--(EmuMath::Vector<Size_, T_>& vector_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_pre_decrement_default_operator_arg<Size_, T_>(),
+		EmuMath::Vector<Size_, T_>&
+	>
+{
+	return EmuMath::Helpers::vector_pre_decrement(vector_);
+}
+
+/// <summary>
+/// <para> Default post-decrement operator for EmuMath Vectors. </para>
+/// </summary>
+/// <param name="vector_">EmuMath Vector to perform the post-decrement operation on as per `EmuMath::Helpers::vector_post_decrement`.</param>
+/// <returns>Copy to the left-hand Vector before the decrement operation was performed.</returns>
+template<std::size_t Size_, typename T_>
+[[nodiscard]] constexpr inline auto operator--(EmuMath::Vector<Size_, T_>& vector_, int)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_post_decrement_default_operator_arg<Size_, T_>(),
+		EmuMath::Vector<Size_, T_>
+	>
+{
+	return EmuMath::Helpers::vector_post_decrement(vector_);
+}
+#pragma endregion
+
+#pragma region CONST_BITWISE_VALIDITY_CHECKS
+namespace EmuMath::Helpers
+{
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_and_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_or_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_xor_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_shift_left_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_shift_right_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_not_default_operator_args()
+	{
+		return true;
+	}
+}
+#pragma endregion
+
+#pragma region CONST_BITWISE
+/// <summary>
+/// <para> Default bitwise AND operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise AND.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the bitwise AND as in `EmuMath::Helpers::vector_bitwise_and`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_bitwise_and` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator&(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_and_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_bitwise_and<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default bitiwse OR operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise OR.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_bitwise_or`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_bitwise_or` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator|(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_or_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_bitwise_or<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default bitwise XOR operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise XOR.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_bitwise_xor`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_bitwise_xor` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator^(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_xor_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_bitwise_xor<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default left-shift operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of left-shift.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_shift_left`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_shift_left` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator<<(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_shift_left_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_shift_left<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default right-shift operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the right-hand side of left-shift.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_shift_right`.</param>
+/// <returns>EmuMath Vector of the left-hand size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_shift_right` with the given args.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator>>(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_shift_right_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_shift_right<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default bitwise NOT operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector to calculate the bitwise NOT of.</param>
+/// <returns>EmuMath Vector of the input size and `value_type_uq` containing the results of `EmuMath::Helpers::vector_bitwise_not` with the given arg.</returns>
+template<std::size_t LhsSize_, typename LhsT_>
+[[nodiscard]] constexpr inline auto operator~(const EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_not_default_operator_args<LhsSize_, LhsT_>(),
+		EmuMath::Vector<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>
+	>
+{
+	return EmuMath::Helpers::vector_bitwise_not<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_);
+}
+#pragma endregion
+
+#pragma region BITWISE_ASSIGN_VALIDITY_CHECKS
+namespace EmuMath::Helpers
+{
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_and_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_bitwise_and_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_or_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_bitwise_or_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_xor_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_bitwise_xor_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+#if 0 // Not provided, may be considered a defect but low priority
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_shift_left_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_bitwise_shift_left_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+	[[nodiscard]] constexpr inline bool vector_valid_bitwise_shift_right_assign_default_operator_args()
+	{
+		return EmuMath::Helpers::vector_valid_bitwise_shift_right_default_operator_args<LhsSize_, LhsT_, Rhs_>();
+	}
+#endif
+}
+#pragma endregion
+
+#pragma region BITWISE_ASSIGN
+/// <summary>
+/// <para> Default bitwise AND-assign operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise AND.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the bitwise AND as in `EmuMath::Helpers::vector_bitwise_and_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator&=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_and_assign_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_bitwise_and_assign<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default bitiwse OR-assign operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise OR.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of subtraction as in `EmuMath::Helpers::vector_bitwise_or_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator|=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_or_assign_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_bitwise_or_assign<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+
+/// <summary>
+/// <para> Default bitwise XOR-assign operator for EmuMath Vectors. </para>
+/// <para> Outputs a Vector of the input left-hand size with the input Vector's `value_type_uq` as its type argument. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the bitwise XOR.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of addition as in `EmuMath::Helpers::vector_bitwise_xor_assign`.</param>
+/// <returns>Reference to the left-hand Vector.</returns>
+template<std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator^=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t
+	<
+		EmuMath::Helpers::vector_valid_bitwise_xor_assign_default_operator_args<LhsSize_, LhsT_, Rhs_>(),
+		EmuMath::Vector<LhsSize_, LhsT_>&
+	>
+{
+	EmuMath::Helpers::vector_bitwise_xor_assign<LhsSize_, typename EmuMath::Vector<LhsSize_, LhsT_>::value_type_uq>(lhs_vector_, std::forward<Rhs_>(rhs_));
+	return lhs_vector_;
+}
+#pragma endregion
+
+#pragma region CMP_VALIDITY_CHECKS
+namespace EmuMath::Helpers
+{
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_equal_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_not_equal_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_less_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_greater_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_less_equal_default_operator_args()
+	{
+		return true;
+	}
+
+	template<std::size_t LhsSize_, typename LhsT_, typename Rhs_, bool IncludeNonContained_ = true>
+	[[nodiscard]] constexpr inline bool vector_valid_cmp_greater_equal_default_operator_args()
+	{
+		return true;
+	}
+}
+#pragma endregion
+
+#pragma region CMP
+/// <summary>
+/// <para> Default equality comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_equal`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator==(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_equal_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_equal<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default inequality comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_not_equal`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator!=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_not_equal_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_not_equal<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default less-than comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// <para> If `rhs_` is an EmuMath Vector, this compares the magnitudes of thw two Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_less`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator<(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_less_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_less<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default greater-than comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// <para> If `rhs_` is an EmuMath Vector, this compares the magnitudes of thw two Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_greater`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator>(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_less_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_greater<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default less-equal comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// <para> If `rhs_` is an EmuMath Vector, this compares the magnitudes of thw two Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_less_equal`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator<=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_less_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_less_equal<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+
+/// <summary>
+/// <para> Default greater-equal comparison operator for EmuMath Vectors. </para>
+/// <para> 
+///		By default, non-contained indices are included in the comparison. To limit only to the size of the smallest included Vector (if rhs is a Vector), 
+///		`IncludeNonContained_` may be set to false.
+/// </para>
+/// <para> If `rhs_` is an EmuMath Vector, this compares the magnitudes of thw two Vectors. </para>
+/// </summary>
+/// <param name="lhs_vector_">EmuMath Vector appearing on the left-hand side of the comparison.</param>
+/// <param name="rhs_">Argument appearing on the right-hand side of the comparison as in `EmuMath::Helpers::vector_cmp_greater_equal`.</param>
+/// <returns>Boolean result of the comparison.</returns>
+template<bool IncludeNonContained_ = true, std::size_t LhsSize_, typename LhsT_, typename Rhs_>
+[[nodiscard]] constexpr inline auto operator>=(EmuMath::Vector<LhsSize_, LhsT_>& lhs_vector_, Rhs_&& rhs_)
+	-> std::enable_if_t<EmuMath::Helpers::vector_valid_cmp_less_default_operator_args<LhsSize_, LhsT_, Rhs_, IncludeNonContained_>(), bool>
+{
+	return EmuMath::Helpers::vector_cmp_greater_equal<IncludeNonContained_>(lhs_vector_, std::forward<Rhs_>(rhs_));
+}
+#pragma endregion
+
+#endif

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -566,6 +566,12 @@ namespace EmuMath
 		{
 			return valid_args_for_variadic_constructor<0, Args_...>();
 		}
+
+		template<class...Args_>
+		[[nodiscard]] static constexpr inline bool is_variadic_constructor_explicit()
+		{
+			return sizeof...(Args_) != size || EmuCore::TMP::is_any_check<EmuMath::TMP::is_emu_vector, Args_...>::value;
+		}
 #pragma endregion
 
 #pragma region UNDERLYING_CONSTRUCTION_HELPERS
@@ -1075,11 +1081,11 @@ namespace EmuMath
 
 		template
 		<
-			class...ConstructionArgs_,
-			typename = std::enable_if_t<valid_args_for_variadic_constructor<0, ConstructionArgs_...>()>
+			class...Args_,
+			typename = std::enable_if_t<valid_args_for_variadic_constructor<0, Args_...>()>
 		>
-		explicit constexpr inline Vector(ConstructionArgs_&&...construction_args_) :
-			_data(_variadic_construct<0>(std::forward<ConstructionArgs_>(construction_args_)...))
+		explicit(is_variadic_constructor_explicit<Args_...>()) constexpr inline Vector(Args_&&...construction_args_) : 
+			_data(_variadic_construct<0>(std::forward<Args_>(construction_args_)...))
 		{
 		}
 #pragma region ACCESS

--- a/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
+++ b/EmuMath/EmuMath/EmuMath/_do_not_manually_include/_vectors/_vector_t.h
@@ -85,15 +85,15 @@ namespace EmuMath
 			return EmuMath::Helpers::vector_get_non_contained<this_type>();
 		}
 
-		// Helper to decide if a type should be an EmuMath Vector of size Size__ and type T__, or void.
-		// --- If std::is_void_v<T__> is true, the underlying type will be void; otherwise, it will be Vector<Size__, T__>.
-		template<std::size_t Size__, typename T__, typename = void>
+		// Helper to decide if a type should be an EmuMath Vector of size InSize_ and type U_, or void.
+		// --- If std::is_void_v<U_> is true, the underlying type will be void; otherwise, it will be Vector<InSize_, U_>.
+		template<std::size_t InSize_, typename U_, typename = void>
 		struct _vector_or_void
 		{
-			using type = EmuMath::Vector<Size__, T__>;
+			using type = EmuMath::Vector<InSize_, U_>;
 		};
-		template<std::size_t Size__, typename T__>
-		struct _vector_or_void<Size__, T__, std::enable_if_t<std::is_void_v<T__>>>
+		template<std::size_t InSize_, typename U_>
+		struct _vector_or_void<InSize_, U_, std::enable_if_t<std::is_void_v<U_>>>
 		{
 			using type = void;
 		};
@@ -1502,90 +1502,6 @@ namespace EmuMath
 		}
 #pragma endregion
 
-#pragma region UNARY_ARITHMETIC_OPERATORS
-	public:
-		// INCREMENT OPERATORS
-		constexpr inline this_type& operator++()
-		{
-			return EmuMath::Helpers::vector_pre_increment(*this);
-		}
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator++()
-		{
-			return EmuMath::Helpers::vector_pre_increment<OutSize_, OutT_>(*this);
-		}
-		template<typename OutT_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator++()
-		{
-			return EmuMath::Helpers::vector_pre_increment<size, OutT_>(*this);
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator++(int)
-		{
-			return EmuMath::Helpers::vector_post_increment<OutSize_, OutT_>(*this);
-		}
-		template<typename OutT_ = value_type_uq>
-		constexpr inline typename _vector_or_void<size, OutT_>::type operator++(int)
-		{
-			if constexpr (std::is_void_v<OutT_>)
-			{
-				EmuMath::Helpers::vector_post_increment_no_copy(*this);
-			}
-			else
-			{
-				return EmuMath::Helpers::vector_post_increment<size, OutT_>(*this);
-			}
-		}
-
-		// DECREMENT OPERATORS
-		constexpr inline this_type& operator--()
-		{
-			return EmuMath::Helpers::vector_pre_decrement(*this);
-		}
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator--()
-		{
-			return EmuMath::Helpers::vector_pre_decrement<OutSize_, OutT_>(*this);
-		}
-		template<typename OutT_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator--()
-		{
-			return EmuMath::Helpers::vector_pre_decrement<size, OutT_>(*this);
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator--(int)
-		{
-			return EmuMath::Helpers::vector_post_decrement<OutSize_, OutT_>(*this);
-		}
-		template<typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline typename _vector_or_void<size, OutT_>::type operator--(int)
-		{
-			if constexpr (std::is_void_v<OutT_>)
-			{
-				EmuMath::Helpers::vector_post_decrement_no_copy(*this);
-			}
-			else
-			{
-				return EmuMath::Helpers::vector_post_decrement<size, OutT_>(*this);
-			}
-		}
-		
-		// NEGATION OPERATORS
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator-() const
-		{
-			return EmuMath::Helpers::vector_negate<OutSize_, OutT_>(*this);
-		}
-
-		template<typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator-() const
-		{
-			return EmuMath::Helpers::vector_negate<size, OutT_>(*this);
-		}
-#pragma endregion
-
 #pragma region ASSIGNMENT_OPERATORS
 		constexpr inline this_type& operator=(this_type& rhs_)
 		{
@@ -1626,15 +1542,7 @@ namespace EmuMath
 		constexpr inline auto operator=(alternative_rep&& rhs_)
 			-> std::enable_if_t<_can_alt_move_assign<Unused_>(), this_type&>
 		{
-			EmuMath::Helpers::vector_copy(*this, std::forward<alternative_rep>(rhs_));
-			return *this;
-		}
-
-		template<std::size_t Unused_ = 0>
-		constexpr inline auto operator=(const alternative_rep&& rhs_)
-			-> std::enable_if_t<_can_alt_const_move_assign<Unused_>(), this_type&>
-		{
-			EmuMath::Helpers::vector_copy(*this, std::forward<alternative_rep>(rhs_));
+			EmuMath::Helpers::vector_copy(*this, std::move(rhs_));
 			return *this;
 		}
 
@@ -1661,296 +1569,6 @@ namespace EmuMath
 		}
 #pragma endregion
 
-#pragma region CONST_ARITHMETIC_OPERATORS
-	public:
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator+(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_add<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator+(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_add<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator-(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_subtract<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator-(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_subtract<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator*(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_multiply<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator*(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_multiply<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator/(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_divide<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator/(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_divide<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator%(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_mod<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator%(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_mod<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-#pragma endregion
-
-#pragma region CONST_BITWISE_OPERATORS
-	public:
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator~() const
-		{
-			return EmuMath::Helpers::vector_bitwise_not<OutSize_, OutT_>(*this);
-		}
-		template<typename OutT_ = value_type_uq>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator~() const
-		{
-			return EmuMath::Helpers::vector_bitwise_not<size, OutT_>(*this);
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator&(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_and<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator&(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_and<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator|(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_or<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator|(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_or<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator^(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_xor<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator^(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_bitwise_xor<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator<<(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_shift_left<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator<<(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_shift_left<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> operator>>(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_shift_right<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> operator>>(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_shift_right<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
-		}
-#pragma endregion
-
-#pragma region CMP_OPERATORS
-	public:
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator==(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_equal<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator==(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_equal<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator!=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_not_equal<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator!=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_not_equal<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator>(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_greater<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator>(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_greater<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator<(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_less<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator<(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_less<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator>=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_greater_equal<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator>=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_greater_equal<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<bool IncludeNonContained_ = true, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator<=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_less_equal<IncludeNonContained_>(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, class Rhs_>
-		[[nodiscard]] constexpr inline bool operator<=(Rhs_&& rhs_) const
-		{
-			return EmuMath::Helpers::vector_cmp_less_equal<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-#pragma endregion
-
-#pragma region ARITHMETIC_ASSIGN_OPERATORS
-	public:
-		template<typename Rhs_>
-		constexpr inline this_type& operator+=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_add_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator+=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_add_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator-=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_subtract_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator-=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_subtract_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator*=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_multiply_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator*=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_multiply_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator/=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_divide_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator/=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_divide_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator%=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_mod_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator%=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_mod_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-#pragma endregion
-
-#pragma region BITWISE_ASSIGN_OPERATORS
-	public:
-		template<typename Rhs_>
-		constexpr inline this_type& operator&=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_and_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator&=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_and_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator|=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_or_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator|=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_or_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-
-		template<typename Rhs_>
-		constexpr inline this_type& operator^=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_xor_assign(*this, std::forward<Rhs_>(rhs_));
-		}
-		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_>
-		constexpr inline this_type& operator^=(Rhs_&& rhs_)
-		{
-			return EmuMath::Helpers::vector_bitwise_xor_assign<BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
-		}
-#pragma endregion
-
 #pragma region UNARY_ARITHMETIC_FUNCS
 	public:
 		/// <summary>
@@ -1961,11 +1579,13 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::vector_pre_increment(*this);
 		}
+
 		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
 		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> PreIncrement()
 		{
 			return EmuMath::Helpers::vector_pre_increment<OutSize_, OutT_>(*this);
 		}
+
 		template<typename OutT_>
 		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> PreIncrement()
 		{
@@ -1982,6 +1602,7 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::vector_post_increment<OutSize_, OutT_>(*this);
 		}
+
 		template<typename OutT_ = value_type_uq>
 		constexpr inline typename _vector_or_void<size, OutT_>::type PostIncrement()
 		{
@@ -2003,11 +1624,13 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::vector_pre_decrement(*this);
 		}
+
 		template<std::size_t OutSize_, typename OutT_ = value_type_uq>
 		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> PreDecrement()
 		{
 			return EmuMath::Helpers::vector_pre_decrement<OutSize_, OutT_>(*this);
 		}
+
 		template<typename OutT_>
 		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> PreDecrement()
 		{
@@ -2024,6 +1647,7 @@ namespace EmuMath
 		{
 			return EmuMath::Helpers::vector_post_decrement<OutSize_, OutT_>(*this);
 		}
+
 		template<typename OutT_ = value_type_uq>
 		constexpr inline typename _vector_or_void<size, OutT_>::type PostDecrement()
 		{
@@ -2348,16 +1972,20 @@ namespace EmuMath
 		/// <summary>
 		/// <para> Returns the result of multiplying this Vector by rhs_. </para>
 		/// <para> If Rhs_ is an EmuMath Vector: Respective elements will be multiplied. Otherwise, all elements are multiplied by rhs_. </para>
+		/// <para> This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases. </para>
 		/// </summary>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
 		/// <returns>Copy of this Vector multiplied by rhs_, using the OutSize_ arg (defaults to size) and OutT_ arg (defaults to value_type_uq).</returns>
 		template<std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> Multiply(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiply(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<OutSize_, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply<OutSize_, OutT_>(*this, std::forward<Rhs_>(rhs_));
 		}
+
 		template<typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> Multiply(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiply(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<size, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply<size, OutT_>(*this, std::forward<Rhs_>(rhs_));
 		}
@@ -2365,11 +1993,13 @@ namespace EmuMath
 		/// <summary>
 		/// <para> Outputs the result of multiplying this Vector by rhs_, via the provided out_vector_. </para>
 		/// <para> If Rhs_ is an EmuMath Vector: Respective elements will be multiplied. Otherwise, all elements are multiplied by rhs_. </para>
+		/// <para> This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases. </para>
 		/// </summary>
 		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply this Vector by.</param>
 		template<typename Rhs_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void Multiply(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+		constexpr inline auto BasicMultiply(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, void>
 		{
 			EmuMath::Helpers::vector_multiply(out_vector_, *this, std::forward<Rhs_>(rhs_));
 		}
@@ -2379,6 +2009,10 @@ namespace EmuMath
 		/// <para> If Rhs_ is an EmuMath Vector: Respective elements will be multiplied. Otherwise, all elements are multiplied by rhs_. </para>
 		/// <para> BeginIndex_: Inclusive index at which to start multiplying elements. </para>
 		/// <para> EndIndex_: Exclusive index at which to stop multiplying elements. </para>
+		/// <para> 
+		///		This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases, 
+		///		although you may not do a range-based matrix multiplication as this function does.
+		/// </para>
 		/// </summary>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply elements by in the specified range.</param>
 		/// <returns>
@@ -2386,12 +2020,14 @@ namespace EmuMath
 		///		with indices in the provided range multiplied by rhs_.
 		/// </returns>
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> MultiplyRange(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiplyRange(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<OutSize_, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply_range<OutSize_, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
 		}
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> MultiplyRange(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiplyRange(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<size, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply_range<size, OutT_, BeginIndex_, EndIndex_>(*this, std::forward<Rhs_>(rhs_));
 		}
@@ -2404,11 +2040,16 @@ namespace EmuMath
 		/// <para> If Rhs_ is an EmuMath Vector: Respective elements will be multiplied. Otherwise, all elements are multiplied by rhs_. </para>
 		/// <para> BeginIndex_: Inclusive index at which to start multiplying elements. </para>
 		/// <para> EndIndex_: Exclusive index at which to stop multiplying elements. </para>
+		/// <para> 
+		///		This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases, 
+		///		although you may not do a range-based matrix multiplication as this function does.
+		/// </para>
 		/// </summary>
 		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply elements by in the specified range.</param>
 		template<std::size_t BeginIndex_, std::size_t EndIndex_, typename Rhs_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void MultiplyRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+		constexpr inline auto BasicMultiplyRange(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, void>
 		{
 			EmuMath::Helpers::vector_multiply_range<BeginIndex_, EndIndex_>(out_vector_, *this, std::forward<Rhs_>(rhs_));
 		}
@@ -2420,6 +2061,10 @@ namespace EmuMath
 		/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 		/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 		/// <para> MulBegin_: Inclusive index at which to start reading elements from this Vector (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
+		/// <para> 
+		///		This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases, 
+		///		although you may not do a range-based matrix multiplication as this function does.
+		/// </para>
 		/// </summary>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply elements by in the specified range.</param>
 		/// <returns>
@@ -2427,12 +2072,14 @@ namespace EmuMath
 		///		with indices within this Vector multiplied by rhs_ in the provided range, and default-constructed elements elsewhere.
 		/// </returns>
 		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t MulBegin_, std::size_t OutSize_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<OutSize_, OutT_> MultiplyRangeNoCopy(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiplyRangeNoCopy(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<OutSize_, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply_range_no_copy<OutSize_, OutT_, OutBegin_, OutEnd_, MulBegin_>(*this, std::forward<Rhs_>(rhs_));
 		}
 		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t MulBegin_, typename OutT_ = value_type_uq, typename Rhs_>
-		[[nodiscard]] constexpr inline EmuMath::Vector<size, OutT_> MultiplyRangeNoCopy(Rhs_&& rhs_) const
+		[[nodiscard]] constexpr inline auto BasicMultiplyRangeNoCopy(Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, EmuMath::Vector<size, OutT_>>
 		{
 			return EmuMath::Helpers::vector_multiply_range_no_copy<size, OutT_, OutBegin_, OutEnd_, MulBegin_>(*this, std::forward<Rhs_>(rhs_));
 		}
@@ -2444,11 +2091,16 @@ namespace EmuMath
 		/// <para> OutBegin_: Inclusive index at which to start writing arithmetic results to the output Vector. </para>
 		/// <para> OutEnd_: Exclusive index at which to stop writing arithmetic results to the output Vector. </para>
 		/// <para> MulBegin_: Inclusive index at which to start reading elements from this Vector (and rhs_ if it is an EmuMath Vector) to perform arithmetic. </para>
+		/// <para> 
+		///		This cannot be used to multiply by an EmuMath Matrix. Use `operator*` for such use cases, 
+		///		although you may not do a range-based matrix multiplication as this function does.
+		/// </para>
 		/// </summary>
 		/// <param name="out_vector_">: EmuMath Vector to output to.</param>
 		/// <param name="rhs_">: Scalar or EmuMath Vector to multiply elements by in the specified range.</param>
 		template<std::size_t OutBegin_, std::size_t OutEnd_, std::size_t MulBegin_, typename Rhs_, std::size_t OutSize_, typename OutT_>
-		constexpr inline void MultiplyRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+		constexpr inline auto BasicMultiplyRangeNoCopy(EmuMath::Vector<OutSize_, OutT_>& out_vector_, Rhs_&& rhs_) const
+			-> std::enable_if_t<!EmuMath::TMP::is_emu_matrix_v<Rhs_>, void>
 		{
 			EmuMath::Helpers::vector_multiply_range_no_copy<OutBegin_, OutEnd_, MulBegin_>(out_vector_, *this, std::forward<Rhs_>(rhs_));
 		}

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -691,8 +691,16 @@ int main()
 		std::cout << "HBTRGFHBKGFRNBOLGFNBKGFNBOGFNBFGB" << "\n";
 	}
 
-	EmuCore::TMP::type_check_ignore_ref_cv<std::is_integral, int>;
+	constexpr auto translation = EmuMath::Helpers::matrix_make_translation<float>(1, 2, 3).Transpose();
+	constexpr auto translated_test = EmuMath::Vector<3, float>(1, 1, 1) * translation;
+	constexpr auto normal_mul_test = EmuMath::Vector<3, float>(1, 1, 1) * 29;
+	constexpr auto hmm = EmuMath::Vector<3, float>(10, 10, 10) * (translation);
+	constexpr auto bloog = -hmm;
 
+	auto runtime_trans = EmuMath::Vector<3, float>(-5, 0, 5);
+	std::cout << "Before trans: " << runtime_trans << "\n";
+	runtime_trans *= translation;
+	std::cout << "After trans: " << runtime_trans << "\n ";
 
 
 

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -627,6 +627,12 @@ int main()
 	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
+	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
+	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+	auto yoiyoi = vec_from_init_list;
+	yoiyoi = { 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24 };
+
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -23,6 +23,11 @@
 // Fast Vector
 #include "EmuMath/FastVector.h"
 
+#include "EmuCore/ArithmeticHelpers/CommonAlgebra.h"
+
+constexpr auto test_dot = EmuCore::dot<float>(1, 2, 6, 3, 7, 10);
+constexpr auto test_dot_2 = EmuCore::dot(5, 7);
+
 template<typename T_, std::size_t Size_>
 inline std::ostream& operator<<(std::ostream& str_, const std::array<T_, Size_>& arr_)
 {
@@ -627,9 +632,11 @@ int main()
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
-	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+	constexpr auto vec_from_init_list = std::move(EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
 	auto yoiyoi = vec_from_init_list;
 
+	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);
+	constexpr auto mbmfgkbmlk = EmuMath::Helpers::rect_get_left(EmuMath::Rect<int>(1, 2, 3, 4));
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -646,6 +646,15 @@ int main()
 	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);
 	constexpr auto mbmfgkbmlk = EmuMath::Helpers::rect_get_left(EmuMath::Rect<int>(1, 2, 3, 4));
 
+	constexpr auto collide_a = EmuMath::Rect<float>(0, 0, 5, 5);
+	constexpr auto collide_b = EmuMath::Rect<double>(5, 5, 6, 6);
+	constexpr auto colliding_a = collide_a.CollidingAxisAligned<true>(collide_b);
+	constexpr auto colliding_b = collide_a.CollidingAxisAligned<false>(collide_b);
+	constexpr auto colliding_c = collide_a.CollidingAxisAligned(collide_b);
+	constexpr auto colliding_d = collide_a.CollidingAxisAligned(collide_b.Translate(-0.2, -0.5));
+	constexpr auto colliding_e = collide_a.CollidingAxisAligned(collide_b.Scale(2, 2));
+	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -12,6 +12,7 @@
 #include "EmuMath/Noise.h"
 #include "EmuMath/Quaternion.h"
 #include "EmuMath/Random.h"
+#include "EmuMath/Rect.h"
 #include "EmuMath/Vector.h"
 
 // Test harness execution
@@ -581,6 +582,15 @@ int main()
 		100.0
 	);
 	std::cout << perspective_mat << "\n" << perspective_mat.Flatten() << "\n";
+
+	constexpr auto rect = EmuMath::Rect<float>(5);
+	constexpr auto rect_centre = rect.Centre();
+	constexpr auto rect_b = EmuMath::Rect<double>(3, 4.2, 10, 10);
+	constexpr auto rect_b_centre = rect_b.Centre();
+	constexpr auto rect_well_formed = rect.WellFormed();
+	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
+	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
+	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(EmuMath::Vector<2, int>(3, 217));
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -604,6 +604,29 @@ int main()
 	constexpr auto reduce_scaled_width = reduce_scaled_rect.Width();
 	constexpr auto reduce_scaled_size = reduce_scaled_rect.Size();
 
+	constexpr auto to_reflect = EmuMath::Rect<float>(1.5, 3, 2, 4);
+	constexpr auto reflect_a = to_reflect.Reflect<0, 0>();
+	constexpr auto reflect_b = to_reflect.Reflect<-1, 0>();
+	constexpr auto reflect_c = to_reflect.Reflect<1, 0>();
+	constexpr auto reflect_d = to_reflect.Reflect<0, -1>();
+	constexpr auto reflect_e = to_reflect.Reflect<0, 1>();
+	constexpr auto reflect_f = to_reflect.Reflect<-1, -1>();
+	constexpr auto reflect_g = to_reflect.Reflect<-1, 1>();
+	constexpr auto reflect_h = to_reflect.Reflect<1, -1>();
+	constexpr auto reflect_i = to_reflect.Reflect<1, 1>();
+	constexpr auto reflect_j = to_reflect.Reflect<1, 1>().Reflect<-1, -1>();
+
+	constexpr auto reflect_alt_a = to_reflect.Reflect(0, 0);
+	constexpr auto reflect_alt_b = to_reflect.Reflect(-1, 0);
+	constexpr auto reflect_alt_c = to_reflect.Reflect(1, 0);
+	constexpr auto reflect_alt_d = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_e = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_f = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_g = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_h = to_reflect.Reflect(0, -1);
+	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
+	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -591,6 +591,18 @@ int main()
 	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
 	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
 	constexpr auto central_contains_point_a_ = rect_made_central.ContainsPoint(4, 3);
+	constexpr auto rect_to_scale = EmuMath::Rect<float>(1, -2, 2.5, 4.17);
+	constexpr auto pre_scale_centre = rect_to_scale.Centre();
+	constexpr auto pre_scale_width = rect_to_scale.Width();
+	constexpr auto pre_scale_size = rect_to_scale.Size();
+	constexpr auto scaled_rect = rect_to_scale * 2;
+	constexpr auto scaled_centre = scaled_rect.Centre();
+	constexpr auto scaled_width = scaled_rect.Width();
+	constexpr auto scaled_size = scaled_rect.Size();
+	constexpr auto reduce_scaled_rect = rect_to_scale * 0.5;
+	constexpr auto reduce_scaled_centre = reduce_scaled_rect.Centre();
+	constexpr auto reduce_scaled_width = reduce_scaled_rect.Width();
+	constexpr auto reduce_scaled_size = reduce_scaled_rect.Size();
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -655,6 +655,8 @@ int main()
 	constexpr auto colliding_e = collide_a.CollidingAxisAligned(collide_b.Scale(2, 2));
 	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
 
+	auto ree = EmuMath::Rect<double>();
+
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####
 	//constexpr EmuMath::NoiseType test_noise_type_flag = EmuMath::NoiseType::PERLIN;

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -686,6 +686,15 @@ int main()
 	std::cout << "Translated (rhs): " <<
 		EmuMath::Helpers::matrix_multiply<float>(EmuMath::Helpers::matrix_make_translation<float>(1, 2, 3), point_to_project_3d) << "\n";
 
+	if constexpr (EmuCore::TMP::type_check_ignore_ref_cv<std::is_integral, const int&>::value)
+	{
+		std::cout << "HBTRGFHBKGFRNBOLGFNBKGFNBOGFNBFGB" << "\n";
+	}
+
+	EmuCore::TMP::type_check_ignore_ref_cv<std::is_integral, int>;
+
+
+
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -577,16 +577,6 @@ int main()
 
 	std::cout << "\n\n" << mat_from_quats << "\n\n" << mat_from_fused_quats << "\n";
 
-	std::cout << "\n\n";
-	constexpr auto perspective_mat = EmuMath::Helpers::matrix_perspective_vk_reverse_depth_constexpr<double>
-	(
-		0.785398,
-		1920.0 / 1080.0,
-		0.1,
-		100.0
-	);
-	std::cout << perspective_mat << "\n" << perspective_mat.Flatten() << "\n";
-
 	constexpr auto rect = EmuMath::Rect<float>(5);
 	constexpr auto rect_centre = rect.Centre();
 	constexpr auto rect_b = EmuMath::Rect<double>(3, 4.2, 10, 10);
@@ -654,8 +644,21 @@ int main()
 	constexpr auto colliding_d = collide_a.CollidingAxisAligned(collide_b.Translate(-0.2, -0.5));
 	constexpr auto colliding_e = collide_a.CollidingAxisAligned(collide_b.Scale(2, 2));
 	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
+	
 
-	auto ree = EmuMath::Rect<double>();
+	std::cout << "\n\nPERSPECTIVE:\n";
+	constexpr auto perspective_mat = EmuMath::Helpers::matrix_perspective_vk_reverse_depth_constexpr<double>
+	(
+		0.785398,
+		1920.0 / 1080.0,
+		0.1,
+		100.0
+	);
+	std::cout << perspective_mat << "\n\nFlattened: " << perspective_mat.Flatten() << "\n";
+
+	std::cout << "---\n\nORTHO:\n";
+	constexpr auto ortho_a = EmuMath::Helpers::matrix_ortho_vk<float>(EmuMath::Rect<double>(0, 0, 1280, 1280), 0.1, 100.0);
+	std::cout << ortho_a << "\n\nFlattened: " << ortho_a.Flatten() << "\n\n";
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -631,8 +631,16 @@ int main()
 	constexpr auto reflect_alt_i = to_reflect.Reflect(0, 1);
 	constexpr auto reflect_alt_j = to_reflect.Reflect(1, 1).Reflect(-1, -1);
 
+	constexpr auto test_scale_rect_base = EmuMath::Rect<float>(1);
+	constexpr auto scaled_a = test_scale_rect_base.Scale(2);
+	constexpr auto scaled_b = test_scale_rect_base.ScaleAnchored<0, 0>(2, 2);
+	constexpr auto scaled_c = test_scale_rect_base.ScaleAnchored<1, 0>(2, 2);
+	constexpr auto scaled_d = test_scale_rect_base.ScaleAnchored<-1, 0>(2, 2);
+	constexpr auto scaled_e = test_scale_rect_base.ScaleAnchored<0, 1>(2, 2);
+	constexpr auto scaled_f = test_scale_rect_base.ScaleAnchored<1, -1>(2, 2);
+
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
-	constexpr auto vec_from_init_list = std::move(EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
+	constexpr auto vec_from_init_list = EmuMath::Vector<12, float>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 	auto yoiyoi = vec_from_init_list;
 
 	constexpr auto blongo_dongo = EmuMath::Helpers::rect_get_left(rect_from_init_list);

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -322,7 +322,6 @@ int main()
 
 
 	std::cout << "ASSIGN_TRANSLATION TESTS\n";
-	using Mat4x4f32CM = EmuMath::Matrix<4, 4, float, true>;
 	EmuMath::Matrix<4, 4, float, true> translate_assign_matrix(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160);
 	std::cout << translate_assign_matrix << "\n\n";
 	translate_assign_matrix.AssignTranslation(5);
@@ -341,8 +340,8 @@ int main()
 	std::cout << "Constexpr:\n" << rot_0 << "\n\n:Runtime:\n" << EmuMath::Helpers::matrix_make_rotation_3d_z<true, float, false>(-33) << "\n\n";
 
 	std::cout << "ROTATION MEMBER TESTS\n";
-	auto member_rot_runtime = Mat4x4f32CM::make_rotation_3d_z<false>(33);
-	constexpr auto member_rot = Mat4x4f32CM::make_rotation_3d_z_constexpr<4, true, false>(33);
+	auto member_rot_runtime = EmuMath::Matrix<4, 4, float, true>::make_rotation_3d_z<false>(33);
+	constexpr auto member_rot = EmuMath::Matrix<4, 4, float, true>::make_rotation_3d_z_constexpr<4, true, false>(33);
 	std::cout << "runtime: " << (member_rot_runtime * point_to_rotate) << "\n";
 	std::cout << "constexpr: " << (member_rot * point_to_rotate) << "\n";
 
@@ -630,7 +629,6 @@ int main()
 	constexpr EmuMath::Rect<float> rect_from_init_list = { 1, 2, 3, 4 };
 	constexpr EmuMath::Vector<12, float> vec_from_init_list = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 	auto yoiyoi = vec_from_init_list;
-	yoiyoi = { 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24 };
 
 
 	system("pause");

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -572,6 +572,15 @@ int main()
 
 	std::cout << "\n\n" << mat_from_quats << "\n\n" << mat_from_fused_quats << "\n";
 
+	std::cout << "\n\n";
+	constexpr auto perspective_mat = EmuMath::Helpers::matrix_perspective_vk_reverse_depth_constexpr<double>
+	(
+		0.785398,
+		1920.0 / 1080.0,
+		0.1,
+		100.0
+	);
+	std::cout << perspective_mat << "\n" << perspective_mat.Flatten() << "\n";
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -590,7 +590,7 @@ int main()
 	constexpr auto rect_well_formed = rect.WellFormed();
 	constexpr auto rect_temp_well_formed = EmuMath::Rect<float>(0, 3, -1, 3).WellFormed();
 	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(5, 5);
-	constexpr auto rect_made_central = EmuMath::Rect<float>(23, 10).MakeCentred(EmuMath::Vector<2, int>(3, 217));
+	constexpr auto central_contains_point_a_ = rect_made_central.ContainsPoint(4, 3);
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####

--- a/EmuMath/EmuMath/main.cpp
+++ b/EmuMath/EmuMath/main.cpp
@@ -646,8 +646,21 @@ int main()
 	constexpr auto colliding_f = collide_a.CollidingAxisAligned(collide_b.Translate(-5.9, -5.9));
 	
 
-	std::cout << "\n\nPERSPECTIVE:\n";
-	constexpr auto perspective_mat = EmuMath::Helpers::matrix_perspective_vk_reverse_depth_constexpr<double>
+	std::cout << "\n\nPERSPECTIVE (REVERSE DEPTH):\n";
+	constexpr auto point_to_project = EmuMath::Vector<4, float>(1, 2, 3, 1);
+	constexpr auto point_to_project_3d = EmuMath::Vector<3, float>(1, 2, 3);
+	constexpr auto perspective_mat_reverse_z = EmuMath::Helpers::matrix_perspective_vk_reverse_depth_constexpr<double>
+	(
+		0.785398,
+		1920.0 / 1080.0,
+		0.1,
+		100.0
+	);
+	std::cout << perspective_mat_reverse_z << "\n\nFlattened: " << perspective_mat_reverse_z.Flatten() << "\n";
+	std::cout << "Transformed point: " << (perspective_mat_reverse_z * point_to_project) << "\n";
+
+	std::cout << "---\n\nPERSPECTIVE:\n";
+	constexpr auto perspective_mat = EmuMath::Helpers::matrix_perspective_vk_constexpr<double>
 	(
 		0.785398,
 		1920.0 / 1080.0,
@@ -655,10 +668,24 @@ int main()
 		100.0
 	);
 	std::cout << perspective_mat << "\n\nFlattened: " << perspective_mat.Flatten() << "\n";
+	std::cout << "Transformed point: " << (perspective_mat * point_to_project) << "\n";
 
 	std::cout << "---\n\nORTHO:\n";
 	constexpr auto ortho_a = EmuMath::Helpers::matrix_ortho_vk<float>(EmuMath::Rect<double>(0, 0, 1280, 1280), 0.1, 100.0);
 	std::cout << ortho_a << "\n\nFlattened: " << ortho_a.Flatten() << "\n\n";
+	std::cout << "Transformed point: " << (ortho_a * point_to_project) << "\n";
+	std::cout << "Transformed point as mat:\n" << 
+		(EmuMath::Matrix<4, 4, float, false>(point_to_project, EmuMath::Vector<4, float>(), EmuMath::Vector<4, float>(), EmuMath::Vector<4, float>()) * ortho_a) 
+		<< "\n";
+	std::cout << "Transformed point as row vector: " << EmuMath::Helpers::matrix_multiply<float>(point_to_project_3d, ortho_a) << "\n";
+	auto runtime_point_to_project = point_to_project_3d;
+	EmuMath::Helpers::matrix_multiply_assign(runtime_point_to_project, ortho_a);
+	std::cout << "Transformed point as row vector (assigned): " << runtime_point_to_project << "\n";
+	std::cout << "Translated (lhs): " <<
+		EmuMath::Helpers::matrix_multiply<float>(point_to_project_3d, EmuMath::Helpers::matrix_make_translation<float>(1, 2, 3)) << "\n";
+	std::cout << "Translated (rhs): " <<
+		EmuMath::Helpers::matrix_multiply<float>(EmuMath::Helpers::matrix_make_translation<float>(1, 2, 3), point_to_project_3d) << "\n";
+
 
 	system("pause");
 	// // ##### SCALAR vs SIMD NOISE #####


### PR DESCRIPTION
- Provides orthographic and perspective projections aimed at Vulkan
   - These contain `vk` to indicate their intention for Vulkan. Valid projection matrices are typically API-defined, and vary between Vulkan, DirectX, etc...
- Adds `Vector * Matrix` functionality
- Updates `Vector` operators (except `operator=`) to be global-scope operators instead of member operators.
   - This change is expected for all items eventually (see issue #60)
- Adds `Rect` template (see #58)
   - Added during this this branch to allow using a `Rect` to define the space for orthographic projection matrices